### PR TITLE
Add an interactive preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,22 @@
 version = 4
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,16 +31,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
+name = "android-activity"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+checksum = "ee91c0c2905bae44f84bfa4e044536541df26b7703fd0888deeb9060fcc44289"
+dependencies = [
+ "android-properties",
+ "bitflags 2.10.0",
+ "cc",
+ "cesu8",
+ "jni",
+ "jni-sys",
+ "libc",
+ "log",
+ "ndk",
+ "ndk-context",
+ "ndk-sys",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "android-properties"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "android_system_properties"
@@ -71,7 +109,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -82,7 +120,7 @@ checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -95,10 +133,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "log",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-raw-xcb-connection"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
 name = "ash"
@@ -108,6 +169,183 @@ checksum = "39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a"
 dependencies = [
  "libloading 0.7.4",
 ]
+
+[[package]]
+name = "ashpd"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd884d7c72877a94102c3715f3b1cd09ff4fac28221add3e57cfbe25c236d093"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand",
+ "serde",
+ "serde_repr",
+ "url",
+ "zbus",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.2",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.2",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.2",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -149,6 +387,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae85a0696e7ea3b835a453750bf002770776609115e6d25c6d2ff28a8200f7e7"
+dependencies = [
+ "objc-sys",
+]
+
+[[package]]
+name = "block2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68"
+dependencies = [
+ "block-sys",
+ "objc2 0.4.1",
+]
+
+[[package]]
+name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,14 +469,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "calloop"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298"
+dependencies = [
+ "bitflags 2.10.0",
+ "log",
+ "polling",
+ "rustix 0.38.44",
+ "slab",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "calloop"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb9f6e1368bd4621d2c86baa7e37de77a938adf5221e5dd3d6133340101b309e"
+dependencies = [
+ "bitflags 2.10.0",
+ "polling",
+ "rustix 1.1.2",
+ "slab",
+ "tracing",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02"
+dependencies = [
+ "calloop 0.12.4",
+ "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
+dependencies = [
+ "calloop 0.14.3",
+ "rustix 1.1.2",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37521ac7aabe3d13122dc382493e20c9416f299d2ccd5b3a5340a2570cdeb0f3"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -201,6 +554,12 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -241,6 +600,15 @@ name = "clap_lex"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "codespan-reporting"
@@ -296,10 +664,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -312,13 +709,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
 name = "core-graphics-types"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
  "libc",
 ]
 
@@ -363,14 +782,213 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "d3d12"
-version = "0.19.0"
+name = "crypto-common"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e3d747f100290a1ca24b752186f61f6637e1deffe3bf6320de6fcb29510a307"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "d3d12"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b28bfe653d79bd16c77f659305b195b82bb5ce0c0eb2a4846b82ddbd77586813"
 dependencies = [
  "bitflags 2.10.0",
- "libloading 0.8.9",
+ "libloading 0.7.4",
  "winapi",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.3",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+dependencies = [
+ "libloading 0.8.9",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "ecolor"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e6b451ff1143f6de0f33fc7f1b68fecfd2c7de06e104de96c4514de3f5396f8"
+dependencies = [
+ "bytemuck",
+ "emath",
+]
+
+[[package]]
+name = "eframe"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6490ef800b2e41ee129b1f32f9ac15f713233fe3bc18e241a1afe1e4fb6811e0"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "document-features",
+ "egui",
+ "egui-wgpu",
+ "egui-winit",
+ "egui_glow",
+ "image",
+ "js-sys",
+ "log",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "parking_lot",
+ "percent-encoding",
+ "pollster",
+ "raw-window-handle",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "web-time",
+ "wgpu",
+ "winapi",
+ "winit",
+]
+
+[[package]]
+name = "egui"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c97e70a2768de630f161bb5392cbd3874fcf72868f14df0e002e82e06cb798"
+dependencies = [
+ "ahash",
+ "emath",
+ "epaint",
+ "log",
+ "nohash-hasher",
+]
+
+[[package]]
+name = "egui-wgpu"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c7a7c707877c3362a321ebb4f32be811c0b91f7aebf345fb162405c0218b4c"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "document-features",
+ "egui",
+ "epaint",
+ "log",
+ "thiserror 1.0.69",
+ "type-map",
+ "web-time",
+ "wgpu",
+ "winit",
+]
+
+[[package]]
+name = "egui-winit"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac4e066af341bf92559f60dbdf2020b2a03c963415349af5f3f8d79ff7a4926"
+dependencies = [
+ "ahash",
+ "arboard",
+ "egui",
+ "log",
+ "raw-window-handle",
+ "smithay-clipboard",
+ "web-time",
+ "webbrowser",
+ "winit",
+]
+
+[[package]]
+name = "egui_extras"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb783d9fa348f69ed5c340aa25af78b5472043090e8b809040e30960cc2a746"
+dependencies = [
+ "ahash",
+ "egui",
+ "enum-map",
+ "image",
+ "log",
+]
+
+[[package]]
+name = "egui_glow"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e2bdc8b38cfa17cc712c4ae079e30c71c00cd4c2763c9e16dc7860a02769103"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "egui",
+ "glow",
+ "log",
+ "memoffset",
+ "wasm-bindgen",
+ "web-sys",
+ "winit",
 ]
 
 [[package]]
@@ -380,10 +998,126 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "emath"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6a21708405ea88f63d8309650b4d77431f4bc28fb9d8e6f77d3963b51249e6"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "endi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+ "serde",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "epaint"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f0dcc0a0771e7500e94cd1cb797bd13c9f23b9409bdc3c824e2cbc562b7fa01"
+dependencies = [
+ "ab_glyph",
+ "ahash",
+ "bytemuck",
+ "ecolor",
+ "emath",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fax"
@@ -420,13 +1154,16 @@ version = "0.1.0"
 dependencies = [
  "bytemuck",
  "clap",
+ "eframe",
+ "egui_extras",
  "image",
  "pollster",
  "rand",
  "rand_distr",
  "rayon",
+ "rfd",
  "statrs",
- "thiserror",
+ "thiserror 1.0.69",
  "wgpu",
 ]
 
@@ -445,6 +1182,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -474,6 +1217,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.2",
+ "windows-link",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +1328,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -553,27 +1411,27 @@ checksum = "6f56f6318968d03c18e1bcf4857ff88c61157e9da8e47c5f29055d60e1228884"
 dependencies = [
  "log",
  "presser",
- "thiserror",
+ "thiserror 1.0.69",
  "winapi",
  "windows",
 ]
 
 [[package]]
 name = "gpu-descriptor"
-version = "0.2.4"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
  "bitflags 2.10.0",
  "gpu-descriptor-types",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
 name = "gpu-descriptor-types"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf0b36e6f090b7e1d8a4b49c0cb81c1f8376f72198c65dd3ad9ff3556b8b78c"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
  "bitflags 2.10.0",
 ]
@@ -591,12 +1449,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "ahash",
- "allocator-api2",
+ "foldhash",
 ]
 
 [[package]]
@@ -615,7 +1472,7 @@ dependencies = [
  "com",
  "libc",
  "libloading 0.8.9",
- "thiserror",
+ "thiserror 1.0.69",
  "widestring",
  "winapi",
 ]
@@ -627,10 +1484,135 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "icrate"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d3aaff8a54577104bafdf686ff18565c3b6903ca5782a2026ef06e2c7aa319"
+dependencies = [
+ "block2 0.3.0",
+ "dispatch",
+ "objc2 0.4.1",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "image"
@@ -667,10 +1649,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -738,6 +1746,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "libredox"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "redox_syscall 0.5.18",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,10 +1815,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "metal"
-version = "0.27.0"
+name = "memchr"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memmap2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "metal"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5637e166ea14be6063a3f8ba5ccb9a4159df7d8f6d61c02fc3d480b1f90dcfcb"
 dependencies = [
  "bitflags 2.10.0",
  "block",
@@ -808,10 +1875,11 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e3524642f53d9af419ab5e8dd29d3ba155708267667c2f3f06c88c9e130843"
+checksum = "e536ae46fcab0876853bd4a632ede5df4b1c2527a58f6c5a4150fe86be858231"
 dependencies = [
+ "arrayvec",
  "bit-set",
  "bitflags 2.10.0",
  "codespan-reporting",
@@ -819,10 +1887,10 @@ dependencies = [
  "indexmap",
  "log",
  "num-traits",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "spirv",
  "termcolor",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-xid",
 ]
 
@@ -856,6 +1924,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+dependencies = [
+ "bitflags 2.10.0",
+ "jni-sys",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "raw-window-handle",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "ndk-sys"
 version = "0.5.0+25.2.9519653"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +1952,25 @@ checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
 dependencies = [
  "jni-sys",
 ]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "num-complex"
@@ -903,22 +2011,236 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
- "objc_exception",
 ]
 
 [[package]]
-name = "objc_exception"
-version = "0.1.2"
+name = "objc-foundation"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
 dependencies = [
- "cc",
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d"
+dependencies = [
+ "objc-sys",
+ "objc2-encode 3.0.0",
+]
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode 4.1.0",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+dependencies = [
+ "objc2-encode 4.1.0",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.3",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2 0.6.3",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc_id"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+dependencies = [
+ "objc",
 ]
 
 [[package]]
@@ -932,6 +2254,40 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "orbclient"
+version = "0.3.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "247ad146e19b9437f8604c21f8652423595cf710ad108af40e77d3ae6e96b827"
+dependencies = [
+ "libredox",
+]
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "owned_ttf_parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
+dependencies = [
+ "ttf-parser",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -951,7 +2307,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -961,6 +2317,35 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkg-config"
@@ -982,10 +2367,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "pollster"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1001,6 +2409,15 @@ name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+dependencies = [
+ "toml_edit",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1033,6 +2450,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +2466,12 @@ checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -1068,7 +2500,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -1121,6 +2553,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
@@ -1135,10 +2576,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "rfd"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a73a7337fc24366edfca76ec521f51877b114e42dab584008209cca6719251"
+dependencies = [
+ "ashpd",
+ "block",
+ "dispatch",
+ "js-sys",
+ "log",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "pollster",
+ "raw-window-handle",
+ "urlencoding",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "rustversion"
@@ -1156,16 +2652,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "simba"
@@ -1187,6 +2759,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
 name = "slotmap"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,6 +2780,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smithay-client-toolkit"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a"
+dependencies = [
+ "bitflags 2.10.0",
+ "calloop 0.12.4",
+ "calloop-wayland-source 0.2.0",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols 0.31.2",
+ "wayland-protocols-wlr 0.2.0",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
+dependencies = [
+ "bitflags 2.10.0",
+ "calloop 0.14.3",
+ "calloop-wayland-source 0.4.1",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 1.1.2",
+ "thiserror 2.0.17",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols 0.32.9",
+ "wayland-protocols-experimental",
+ "wayland-protocols-misc",
+ "wayland-protocols-wlr 0.3.9",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-clipboard"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71704c03f739f7745053bde45fa203a46c58d25bc5c4efba1d9a60e9dba81226"
+dependencies = [
+ "libc",
+ "smithay-client-toolkit 0.20.0",
+ "wayland-backend",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,6 +2859,12 @@ checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
  "bitflags 2.10.0",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -1258,6 +2914,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix 1.1.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,7 +2952,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -1280,6 +2969,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1301,16 +3001,120 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash 2.1.1",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "uds_windows"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "winapi",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
@@ -1325,6 +3129,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "url"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,10 +3165,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1401,6 +3248,166 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.2",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
+dependencies = [
+ "bitflags 2.10.0",
+ "rustix 1.1.2",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.10.0",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447ccc440a881271b19e9989f75726d60faa09b95b0200a9b7eb5cc47c3eeb29"
+dependencies = [
+ "rustix 1.1.2",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
+dependencies = [
+ "bitflags 2.10.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901"
+dependencies = [
+ "bitflags 2.10.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-experimental"
+version = "20250721.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
+dependencies = [
+ "bitflags 2.10.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols 0.32.9",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-misc"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfe33d551eb8bffd03ff067a8b44bb963919157841a99957151299a6307d19c"
+dependencies = [
+ "bitflags 2.10.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols 0.32.9",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479"
+dependencies = [
+ "bitflags 2.10.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols 0.31.2",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
+dependencies = [
+ "bitflags 2.10.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols 0.31.2",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd94963ed43cf9938a090ca4f7da58eb55325ec8200c3848963e98dc25b78ec"
+dependencies = [
+ "bitflags 2.10.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols 0.32.9",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54cb1e9dc49da91950bdfd8b848c49330536d9d1fb03d4bfec8cae50caa50ae3"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34949b42822155826b41db8e5d0c1be3a2bd296c747577a43a3e6daefc296142"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +3418,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webbrowser"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00f1243ef785213e3a32fa0396093424a3a6ea566f9948497e5a2309261a4c97"
+dependencies = [
+ "core-foundation 0.10.1",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+ "url",
+ "web-sys",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,13 +3451,14 @@ checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
 
 [[package]]
 name = "wgpu"
-version = "0.19.4"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd7311dbd2abcfebaabf1841a2824ed7c8be443a0f29166e5d3c6a53a762c01"
+checksum = "90e37c7b9921b75dfd26dd973fdcbce36f13dfa6e2dc82aece584e0ed48c355c"
 dependencies = [
  "arrayvec",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
+ "document-features",
  "js-sys",
  "log",
  "naga",
@@ -1443,15 +3477,16 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.19.4"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b94525fc99ba9e5c9a9e24764f2bc29bad0911a7446c12f446a8277369bf3a"
+checksum = "d50819ab545b867d8a454d1d756b90cd5f15da1f2943334ca314af10583c9d39"
 dependencies = [
  "arrayvec",
  "bit-vec",
  "bitflags 2.10.0",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "codespan-reporting",
+ "document-features",
  "indexmap",
  "log",
  "naga",
@@ -1459,9 +3494,9 @@ dependencies = [
  "parking_lot",
  "profiling",
  "raw-window-handle",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "web-sys",
  "wgpu-hal",
  "wgpu-types",
@@ -1469,9 +3504,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.19.5"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfabcfc55fd86611a855816326b2d54c3b2fd7972c27ce414291562650552703"
+checksum = "172e490a87295564f3fcc0f165798d87386f6231b04d4548bca458cbbfd63222"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -1479,7 +3514,7 @@ dependencies = [
  "bit-set",
  "bitflags 2.10.0",
  "block",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "core-graphics-types",
  "d3d12",
  "glow",
@@ -1503,9 +3538,9 @@ dependencies = [
  "range-alloc",
  "raw-window-handle",
  "renderdoc-sys",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
@@ -1514,9 +3549,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b671ff9fb03f78b46ff176494ee1ebe7d603393f42664be55b64dc8d53969805"
+checksum = "1353d9a46bff7f955a680577f34c69122628cc2076e1d6f3a9be6ef00ae793ef"
 dependencies = [
  "bitflags 2.10.0",
  "js-sys",
@@ -1561,7 +3596,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1597,11 +3632,86 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1639,6 +3749,18 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -1651,6 +3773,18 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -1660,6 +3794,18 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1687,6 +3833,18 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -1696,6 +3854,18 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1711,6 +3881,18 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -1720,6 +3902,18 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1734,10 +3928,230 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winit"
+version = "0.29.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d59ad965a635657faf09c8f062badd885748428933dad8e8bdd64064d92e5ca"
+dependencies = [
+ "ahash",
+ "android-activity",
+ "atomic-waker",
+ "bitflags 2.10.0",
+ "bytemuck",
+ "calloop 0.12.4",
+ "cfg_aliases 0.1.1",
+ "core-foundation 0.9.4",
+ "core-graphics",
+ "cursor-icon",
+ "icrate",
+ "js-sys",
+ "libc",
+ "log",
+ "memmap2",
+ "ndk",
+ "ndk-sys",
+ "objc2 0.4.1",
+ "once_cell",
+ "orbclient",
+ "percent-encoding",
+ "raw-window-handle",
+ "redox_syscall 0.3.5",
+ "rustix 0.38.44",
+ "smithay-client-toolkit 0.18.1",
+ "smol_str",
+ "unicode-segmentation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols 0.31.2",
+ "wayland-protocols-plasma",
+ "web-sys",
+ "web-time",
+ "windows-sys 0.48.0",
+ "x11-dl",
+ "x11rb",
+ "xkbcommon-dl",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "as-raw-xcb-connection",
+ "gethostname",
+ "libc",
+ "libloading 0.8.9",
+ "once_cell",
+ "rustix 1.1.2",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xcursor"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
+
+[[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "xkbcommon-dl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
+dependencies = [
+ "bitflags 2.10.0",
+ "dlib",
+ "log",
+ "once_cell",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
 name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+ "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "rand",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
+]
 
 [[package]]
 name = "zerocopy"
@@ -1760,6 +4174,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
 name = "zune-core"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1772,4 +4240,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "url",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,6 +1157,7 @@ dependencies = [
  "eframe",
  "egui_extras",
  "image",
+ "log",
  "pollster",
  "rand",
  "rand_distr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,6 +562,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cgl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,6 +901,9 @@ dependencies = [
  "egui-wgpu",
  "egui-winit",
  "egui_glow",
+ "glow",
+ "glutin",
+ "glutin-winit",
  "image",
  "js-sys",
  "log",
@@ -901,7 +913,8 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "pollster",
- "raw-window-handle",
+ "raw-window-handle 0.5.2",
+ "raw-window-handle 0.6.2",
  "static_assertions",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -954,7 +967,7 @@ dependencies = [
  "arboard",
  "egui",
  "log",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "smithay-clipboard",
  "web-time",
  "webbrowser",
@@ -1373,6 +1386,62 @@ dependencies = [
  "slotmap",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "glutin"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18fcd4ae4e86d991ad1300b8f57166e5be0c95ef1f63f3f5b827f8a164548746"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg_aliases 0.1.1",
+ "cgl",
+ "core-foundation 0.9.4",
+ "dispatch",
+ "glutin_egl_sys",
+ "glutin_glx_sys",
+ "glutin_wgl_sys",
+ "icrate",
+ "libloading 0.8.9",
+ "objc2 0.4.1",
+ "once_cell",
+ "raw-window-handle 0.5.2",
+ "wayland-sys",
+ "windows-sys 0.48.0",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin-winit"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebcdfba24f73b8412c5181e56f092b5eff16671c514ce896b258a0a64bd7735"
+dependencies = [
+ "cfg_aliases 0.1.1",
+ "glutin",
+ "raw-window-handle 0.5.2",
+ "winit",
+]
+
+[[package]]
+name = "glutin_egl_sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77cc5623f5309ef433c3dd4ca1223195347fe62c413da8e2fdd0eb76db2d9bcd"
+dependencies = [
+ "gl_generator",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "glutin_glx_sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a165fd686c10dcc2d45380b35796e577eacfd43d4660ee741ec8ebe2201b3b4f"
+dependencies = [
+ "gl_generator",
+ "x11-dl",
 ]
 
 [[package]]
@@ -1934,7 +2003,8 @@ dependencies = [
  "log",
  "ndk-sys",
  "num_enum",
- "raw-window-handle",
+ "raw-window-handle 0.5.2",
+ "raw-window-handle 0.6.2",
  "thiserror 1.0.69",
 ]
 
@@ -2521,6 +2591,12 @@ checksum = "c3d6831663a5098ea164f89cff59c6284e95f4e3c76ce9848d4529f5ccca9bde"
 
 [[package]]
 name = "raw-window-handle"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
+
+[[package]]
+name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
@@ -2590,7 +2666,7 @@ dependencies = [
  "objc-foundation",
  "objc_id",
  "pollster",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "urlencoding",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3464,7 +3540,7 @@ dependencies = [
  "naga",
  "parking_lot",
  "profiling",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "smallvec",
  "static_assertions",
  "wasm-bindgen",
@@ -3493,7 +3569,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "profiling",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 1.0.69",
@@ -3536,7 +3612,7 @@ dependencies = [
  "parking_lot",
  "profiling",
  "range-alloc",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "renderdoc-sys",
  "rustc-hash 1.1.0",
  "smallvec",
@@ -3954,7 +4030,8 @@ dependencies = [
  "once_cell",
  "orbclient",
  "percent-encoding",
- "raw-window-handle",
+ "raw-window-handle 0.5.2",
+ "raw-window-handle 0.6.2",
  "redox_syscall 0.3.5",
  "rustix 0.38.44",
  "smithay-client-toolkit 0.18.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
 ]
 
 [[package]]
@@ -338,7 +338,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
 ]
 
 [[package]]
@@ -459,7 +459,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
 ]
 
 [[package]]
@@ -562,15 +562,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "cgl"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "clap"
 version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,7 +592,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
 ]
 
 [[package]]
@@ -813,7 +804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b28bfe653d79bd16c77f659305b195b82bb5ce0c0eb2a4846b82ddbd77586813"
 dependencies = [
  "bitflags 2.10.0",
- "libloading 0.7.4",
+ "libloading 0.8.9",
  "winapi",
 ]
 
@@ -851,7 +842,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
 ]
 
 [[package]]
@@ -901,9 +892,6 @@ dependencies = [
  "egui-wgpu",
  "egui-winit",
  "egui_glow",
- "glow",
- "glutin",
- "glutin-winit",
  "image",
  "js-sys",
  "log",
@@ -913,8 +901,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "pollster",
- "raw-window-handle 0.5.2",
- "raw-window-handle 0.6.2",
+ "raw-window-handle",
  "static_assertions",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -967,7 +954,7 @@ dependencies = [
  "arboard",
  "egui",
  "log",
- "raw-window-handle 0.6.2",
+ "raw-window-handle",
  "smithay-clipboard",
  "web-time",
  "webbrowser",
@@ -1043,7 +1030,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
 ]
 
 [[package]]
@@ -1064,7 +1051,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
 ]
 
 [[package]]
@@ -1149,7 +1136,7 @@ checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
 ]
 
 [[package]]
@@ -1220,7 +1207,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
 ]
 
 [[package]]
@@ -1280,7 +1267,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
 ]
 
 [[package]]
@@ -1386,62 +1373,6 @@ dependencies = [
  "slotmap",
  "wasm-bindgen",
  "web-sys",
-]
-
-[[package]]
-name = "glutin"
-version = "0.31.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fcd4ae4e86d991ad1300b8f57166e5be0c95ef1f63f3f5b827f8a164548746"
-dependencies = [
- "bitflags 2.10.0",
- "cfg_aliases 0.1.1",
- "cgl",
- "core-foundation 0.9.4",
- "dispatch",
- "glutin_egl_sys",
- "glutin_glx_sys",
- "glutin_wgl_sys",
- "icrate",
- "libloading 0.8.9",
- "objc2 0.4.1",
- "once_cell",
- "raw-window-handle 0.5.2",
- "wayland-sys",
- "windows-sys 0.48.0",
- "x11-dl",
-]
-
-[[package]]
-name = "glutin-winit"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebcdfba24f73b8412c5181e56f092b5eff16671c514ce896b258a0a64bd7735"
-dependencies = [
- "cfg_aliases 0.1.1",
- "glutin",
- "raw-window-handle 0.5.2",
- "winit",
-]
-
-[[package]]
-name = "glutin_egl_sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77cc5623f5309ef433c3dd4ca1223195347fe62c413da8e2fdd0eb76db2d9bcd"
-dependencies = [
- "gl_generator",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "glutin_glx_sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a165fd686c10dcc2d45380b35796e577eacfd43d4660ee741ec8ebe2201b3b4f"
-dependencies = [
- "gl_generator",
- "x11-dl",
 ]
 
 [[package]]
@@ -2003,8 +1934,7 @@ dependencies = [
  "log",
  "ndk-sys",
  "num_enum",
- "raw-window-handle 0.5.2",
- "raw-window-handle 0.6.2",
+ "raw-window-handle",
  "thiserror 1.0.69",
 ]
 
@@ -2099,7 +2029,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
 ]
 
 [[package]]
@@ -2530,9 +2460,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -2588,12 +2518,6 @@ name = "range-alloc"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d6831663a5098ea164f89cff59c6284e95f4e3c76ce9848d4529f5ccca9bde"
-
-[[package]]
-name = "raw-window-handle"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "raw-window-handle"
@@ -2666,7 +2590,7 @@ dependencies = [
  "objc-foundation",
  "objc_id",
  "pollster",
- "raw-window-handle 0.6.2",
+ "raw-window-handle",
  "urlencoding",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2775,7 +2699,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
 ]
 
 [[package]]
@@ -2786,7 +2710,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
 ]
 
 [[package]]
@@ -2980,9 +2904,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.108"
+version = "2.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
+checksum = "2f17c7e013e88258aa9543dcbe81aca68a667a9ac37cd69c9fbc07858bfe0e2f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2997,7 +2921,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
 ]
 
 [[package]]
@@ -3048,7 +2972,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
 ]
 
 [[package]]
@@ -3059,7 +2983,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
 ]
 
 [[package]]
@@ -3136,7 +3060,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
 ]
 
 [[package]]
@@ -3310,7 +3234,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -3540,7 +3464,7 @@ dependencies = [
  "naga",
  "parking_lot",
  "profiling",
- "raw-window-handle 0.6.2",
+ "raw-window-handle",
  "smallvec",
  "static_assertions",
  "wasm-bindgen",
@@ -3569,7 +3493,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "profiling",
- "raw-window-handle 0.6.2",
+ "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 1.0.69",
@@ -3612,7 +3536,7 @@ dependencies = [
  "parking_lot",
  "profiling",
  "range-alloc",
- "raw-window-handle 0.6.2",
+ "raw-window-handle",
  "renderdoc-sys",
  "rustc-hash 1.1.0",
  "smallvec",
@@ -4030,8 +3954,7 @@ dependencies = [
  "once_cell",
  "orbclient",
  "percent-encoding",
- "raw-window-handle 0.5.2",
- "raw-window-handle 0.6.2",
+ "raw-window-handle",
  "redox_syscall 0.3.5",
  "rustix 0.38.44",
  "smithay-client-toolkit 0.18.1",
@@ -4164,7 +4087,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
  "synstructure",
 ]
 
@@ -4215,7 +4138,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
  "zvariant_utils",
 ]
 
@@ -4247,7 +4170,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
 ]
 
 [[package]]
@@ -4267,7 +4190,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
  "synstructure",
 ]
 
@@ -4301,7 +4224,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
 ]
 
 [[package]]
@@ -4342,7 +4265,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
  "zvariant_utils",
 ]
 
@@ -4354,5 +4277,5 @@ checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.109",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ pollster = "0.3"
 eframe = { version = "0.28", default-features = false, features = ["wgpu", "x11", "wayland", "default_fonts"] }
 egui_extras = { version = "0.28", default-features = false, features = ["image"] }
 rfd = "0.14"
+log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ thiserror = "1.0"
 wgpu = { version = "0.20", features = ["wgsl"] }
 bytemuck = { version = "1.14", features = ["derive"] }
 pollster = "0.3"
-eframe = { version = "0.28", default-features = false, features = ["wgpu", "x11", "wayland"] }
+eframe = { version = "0.28", default-features = false, features = ["wgpu", "glow", "x11", "wayland", "default_fonts"] }
 egui_extras = { version = "0.28", default-features = false, features = ["image"] }
 rfd = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ thiserror = "1.0"
 wgpu = { version = "0.20", features = ["wgsl"] }
 bytemuck = { version = "1.14", features = ["derive"] }
 pollster = "0.3"
-eframe = { version = "0.28", default-features = false, features = ["wgpu", "glow", "x11", "wayland", "default_fonts"] }
+eframe = { version = "0.28", default-features = false, features = ["wgpu", "x11", "wayland", "default_fonts"] }
 egui_extras = { version = "0.28", default-features = false, features = ["image"] }
 rfd = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ rand_distr = "0.4"
 rayon = "1.10"
 statrs = "0.16"
 thiserror = "1.0"
-wgpu = { version = "0.19", features = ["wgsl"] }
+wgpu = { version = "0.20", features = ["wgsl"] }
 bytemuck = { version = "1.14", features = ["derive"] }
 pollster = "0.3"
+eframe = { version = "0.28", default-features = false, features = ["wgpu", "x11", "wayland"] }
+egui_extras = { version = "0.28", default-features = false, features = ["image"] }
+rfd = "0.14"

--- a/src/bin/viewer.rs
+++ b/src/bin/viewer.rs
@@ -1,0 +1,275 @@
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use eframe::egui;
+
+use film_grain::{
+    Algo, ColorMode, Device, InputImage, MaxRadius, ParamsBuilder, RadiusDist, RenderStats, Roi,
+};
+
+fn main() -> eframe::Result<()> {
+    let options = eframe::NativeOptions::default();
+    eframe::run_native(
+        "Film Grain Viewer",
+        options,
+        Box::new(|cc| Ok(Box::new(FilmGrainViewer::new(cc)))),
+    )
+}
+
+struct FilmGrainViewer {
+    state: ViewerState,
+}
+
+impl FilmGrainViewer {
+    fn new(_cc: &eframe::CreationContext<'_>) -> Self {
+        Self {
+            state: ViewerState::default(),
+        }
+    }
+}
+
+impl eframe::App for FilmGrainViewer {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::TopBottomPanel::top("viewer_toolbar").show(ctx, |ui| {
+            ui.heading("Film Grain Viewer");
+            if let Some(source) = &self.state.source {
+                ui.label(format!(
+                    "Source: {} ({} × {})",
+                    source.path.display(),
+                    source.width,
+                    source.height
+                ));
+                let builder = self.state.params.to_builder(source);
+                ui.label(format!("Color mode: {:?}", source.cache.color_mode()));
+                ui.label(format!("Output path: {}", builder.output_path.display()));
+            } else {
+                ui.label("No image loaded");
+            }
+            ui.label(format!("Worker: {}", self.state.worker.status_text()));
+            if let Some(path) = &self.state.pending_save_path {
+                ui.label(format!("Pending save: {}", path.display()));
+            }
+        });
+
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.heading("Preview");
+            if let Some(texture) = self.state.preview.texture.as_ref() {
+                let size = texture.size_vec2();
+                ui.add(egui::Image::new((texture.id(), size)));
+                ui.label(format!("Preview size: {:.0} × {:.0}", size.x, size.y));
+            } else {
+                ui.label("Preview not available");
+            }
+            ui.separator();
+            ui.heading("Parameters");
+            self.state.params.show(ui);
+            ui.separator();
+            ui.heading("Render stats");
+            if let Some(stats) = &self.state.last_stats {
+                ui.label(stats_summary(stats));
+            } else {
+                ui.label("No render has completed yet.");
+            }
+        });
+    }
+}
+
+#[derive(Default)]
+struct ViewerState {
+    source: Option<SourceImage>,
+    params: InteractiveParams,
+    last_stats: Option<RenderStats>,
+    preview: PreviewState,
+    worker: WorkerState,
+    pending_save_path: Option<PathBuf>,
+}
+
+struct SourceImage {
+    path: PathBuf,
+    cache: InputImage,
+    width: usize,
+    height: usize,
+}
+
+#[derive(Default)]
+struct PreviewState {
+    texture: Option<egui::TextureHandle>,
+}
+
+struct InteractiveParams {
+    radius_dist: RadiusDist,
+    radius_mean: f32,
+    radius_stddev: f32,
+    zoom: f32,
+    sigma_px: f32,
+    n_samples: u32,
+    algo: Algo,
+    max_radius: MaxRadius,
+    cell_delta: Option<f32>,
+    color_mode: ColorMode,
+    roi: Option<Roi>,
+    size: Option<(u32, Option<u32>)>,
+    seed: u64,
+    dry_run: bool,
+    explain: bool,
+    device: Device,
+    output_path: Option<PathBuf>,
+    output_format: Option<String>,
+}
+
+impl Default for InteractiveParams {
+    fn default() -> Self {
+        Self {
+            radius_dist: RadiusDist::Const,
+            radius_mean: 0.10,
+            radius_stddev: 0.00,
+            zoom: 1.0,
+            sigma_px: 0.8,
+            n_samples: 32,
+            algo: Algo::Auto,
+            max_radius: MaxRadius::Quantile(0.999),
+            cell_delta: None,
+            color_mode: ColorMode::Luma,
+            roi: None,
+            size: None,
+            seed: 5489,
+            dry_run: false,
+            explain: false,
+            device: Device::Cpu,
+            output_path: None,
+            output_format: None,
+        }
+    }
+}
+
+impl InteractiveParams {
+    fn to_builder(&self, source: &SourceImage) -> ParamsBuilder {
+        ParamsBuilder {
+            input_path: source.path.clone(),
+            output_path: self
+                .output_path
+                .clone()
+                .unwrap_or_else(|| default_output_path(&source.path)),
+            radius_dist: self.radius_dist,
+            radius_mean: self.radius_mean,
+            radius_stddev: self.radius_stddev,
+            zoom: self.zoom,
+            sigma_px: self.sigma_px,
+            n_samples: self.n_samples,
+            algo: self.algo,
+            max_radius: self.max_radius,
+            cell_delta: self.cell_delta,
+            color_mode: self.color_mode,
+            roi: self.roi,
+            size: self.size,
+            seed: self.seed,
+            dry_run: self.dry_run,
+            explain: self.explain,
+            device: self.device,
+            output_format: self.output_format.clone(),
+        }
+    }
+
+    fn show(&self, ui: &mut egui::Ui) {
+        ui.label(format!("Radius distribution: {:?}", self.radius_dist));
+        ui.label(format!("Radius mean: {:.3}", self.radius_mean));
+        ui.label(format!("Radius stddev: {:.3}", self.radius_stddev));
+        ui.label(format!("Zoom: {:.3}", self.zoom));
+        ui.label(format!("Sigma (px): {:.3}", self.sigma_px));
+        ui.label(format!("Samples: {}", self.n_samples));
+        ui.label(format!("Algorithm: {:?}", self.algo));
+        ui.label(format!("Device: {:?}", self.device));
+        ui.label(format!(
+            "Max radius: {}",
+            match self.max_radius {
+                MaxRadius::Absolute(v) => format!("absolute {:.3}", v),
+                MaxRadius::Quantile(q) => format!("quantile {:.3}", q),
+            }
+        ));
+        ui.label(format!(
+            "Cell delta: {}",
+            self.cell_delta
+                .map(|d| format!("{:.3}", d))
+                .unwrap_or_else(|| "auto".to_owned())
+        ));
+        ui.label(format!("Color mode: {:?}", self.color_mode));
+        if let Some(roi) = self.roi {
+            ui.label(format!("ROI: {} {} {} {}", roi.x0, roi.y0, roi.x1, roi.y1));
+        } else {
+            ui.label("ROI: full image");
+        }
+        if let Some((width, maybe_height)) = self.size {
+            let text = maybe_height
+                .map(|h| format!("{} × {}", width, h))
+                .unwrap_or_else(|| format!("width {}", width));
+            ui.label(format!("Output size override: {text}"));
+        } else {
+            ui.label("Output size override: none");
+        }
+        ui.label(format!("Seed: {}", self.seed));
+        ui.label(format!("Dry run: {}", self.dry_run));
+        ui.label(format!("Explain: {}", self.explain));
+        if let Some(fmt) = &self.output_format {
+            ui.label(format!("Output format override: {fmt}"));
+        } else {
+            ui.label("Output format override: auto from path");
+        }
+    }
+}
+
+#[derive(Default)]
+struct WorkerState {
+    status: WorkerStatus,
+}
+
+impl WorkerState {
+    fn status_text(&self) -> String {
+        match &self.status {
+            WorkerStatus::Idle => "idle".to_owned(),
+            WorkerStatus::Rendering { started_at } => {
+                format!("rendering (started {}s ago)", elapsed_seconds(*started_at))
+            }
+            WorkerStatus::Completed { finished_at } => {
+                format!("completed {}s ago", elapsed_seconds(*finished_at))
+            }
+            WorkerStatus::Failed { message } => format!("failed: {message}"),
+        }
+    }
+}
+
+#[allow(dead_code)]
+enum WorkerStatus {
+    Idle,
+    Rendering { started_at: Instant },
+    Completed { finished_at: Instant },
+    Failed { message: String },
+}
+
+impl Default for WorkerStatus {
+    fn default() -> Self {
+        WorkerStatus::Idle
+    }
+}
+
+fn elapsed_seconds(instant: Instant) -> u64 {
+    instant.elapsed().as_secs()
+}
+
+fn stats_summary(stats: &RenderStats) -> String {
+    format!(
+        "Algorithm: {:?}, device: {:?}, output: {} × {}, samples: {}, σ/mean {:.3}, rm/mean {:.3}",
+        stats.algorithm,
+        stats.device,
+        stats.output_size.0,
+        stats.output_size.1,
+        stats.n_samples,
+        stats.sigma_ratio,
+        stats.rm_ratio
+    )
+}
+
+fn default_output_path(source: &Path) -> PathBuf {
+    let mut result = source.to_path_buf();
+    result.set_extension("filmgrain.png");
+    result
+}

--- a/src/bin/viewer.rs
+++ b/src/bin/viewer.rs
@@ -214,20 +214,20 @@ impl ViewerState {
         if self.source.is_none() {
             return;
         }
-        if change.require_reload {
-            if let Err(err) = self.reload_source_from_params() {
-                self.set_error(err);
-                return;
-            }
+        if change.require_reload
+            && let Err(err) = self.reload_source_from_params()
+        {
+            self.set_error(err);
+            return;
         }
         if change.request_preview {
             if let Err(err) = self.schedule_render(RenderMode::Preview) {
                 self.set_error(err);
             }
-        } else if change.request_stats_only {
-            if let Err(err) = self.schedule_render(RenderMode::StatsOnly) {
-                self.set_error(err);
-            }
+        } else if change.request_stats_only
+            && let Err(err) = self.schedule_render(RenderMode::StatsOnly)
+        {
+            self.set_error(err);
         }
     }
 
@@ -653,17 +653,16 @@ impl InteractiveParams {
             }
             change.mark_changed();
         }
-        if !self.cell_auto {
-            if ui
+        if !self.cell_auto
+            && ui
                 .add(
                     egui::Slider::new(&mut self.cell_value, 0.01..=5.0)
                         .logarithmic(true)
                         .text("Manual cell size"),
                 )
                 .changed()
-            {
-                change.mark_changed();
-            }
+        {
+            change.mark_changed();
         }
         if cell_auto_prev && !self.cell_auto {
             change.mark_changed();
@@ -921,10 +920,10 @@ impl InteractiveParams {
     }
 
     fn update_output_defaults(&mut self, source_path: &Path) {
-        if self.output_path_override.trim().is_empty() {
-            if let Some(path) = default_output_path(source_path).to_str() {
-                self.output_path_override = path.to_owned();
-            }
+        if self.output_path_override.trim().is_empty()
+            && let Some(path) = default_output_path(source_path).to_str()
+        {
+            self.output_path_override = path.to_owned();
         }
     }
 }
@@ -1180,17 +1179,19 @@ impl WorkerState {
     }
 }
 
+#[derive(Default)]
 enum WorkerStatus {
+    #[default]
     Idle,
-    Rendering { started_at: Instant },
-    Completed { finished_at: Instant },
-    Failed { message: String },
-}
-
-impl Default for WorkerStatus {
-    fn default() -> Self {
-        WorkerStatus::Idle
-    }
+    Rendering {
+        started_at: Instant,
+    },
+    Completed {
+        finished_at: Instant,
+    },
+    Failed {
+        message: String,
+    },
 }
 
 fn stats_summary(stats: &RenderStats) -> String {

--- a/src/bin/viewer.rs
+++ b/src/bin/viewer.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use eframe::egui;
+use eframe::{egui, wgpu};
 
 use film_grain::{
     Algo, ColorMode, Device, InputImage, MaxRadius, Params, ParamsBuilder, RadiusDist, RenderError,
@@ -17,7 +17,10 @@ use rfd::FileDialog;
 
 fn main() -> eframe::Result<()> {
     let mut options = eframe::NativeOptions::default();
-    options.renderer = eframe::Renderer::Glow;
+    options.renderer = eframe::Renderer::Wgpu;
+    // Keep eframe on the modern GPU path (Vulkan/Metal/DX12) to avoid the legacy GL stack.
+    options.wgpu_options.supported_backends = wgpu::Backends::PRIMARY;
+    options.wgpu_options.power_preference = wgpu::PowerPreference::HighPerformance;
     options.follow_system_theme = false;
     options.default_theme = eframe::Theme::Dark;
     options.viewport = egui::viewport::ViewportBuilder::default()

--- a/src/bin/viewer.rs
+++ b/src/bin/viewer.rs
@@ -2,15 +2,17 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, mpsc};
 use std::thread;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use eframe::egui;
 
 use film_grain::{
     Algo, ColorMode, Device, InputImage, MaxRadius, Params, ParamsBuilder, RadiusDist, RenderError,
-    RenderStats, Roi, render_with_input_image,
+    RenderStats, Roi, default_cell_delta, dry_run_with_input_image, render_with_input_image,
 };
 use image::RgbImage;
+use rand::Rng;
+use rfd::FileDialog;
 
 fn main() -> eframe::Result<()> {
     let mut options = eframe::NativeOptions::default();
@@ -56,6 +58,7 @@ struct ViewerState {
     worker_status: WorkerState,
     pending_save_path: Option<PathBuf>,
     worker_runtime: RenderWorker,
+    last_error: Option<String>,
 }
 
 impl ViewerState {
@@ -68,35 +71,67 @@ impl ViewerState {
             worker_status: WorkerState::default(),
             pending_save_path: None,
             worker_runtime: RenderWorker::new(),
+            last_error: None,
         }
     }
 
     fn draw(&mut self, ctx: &egui::Context) {
         egui::TopBottomPanel::top("viewer_toolbar").show(ctx, |ui| {
             ui.horizontal(|ui| {
+                if ui.button("Load Image…").clicked() {
+                    self.prompt_and_load();
+                }
+                let can_save = self.preview.has_image();
+                if ui
+                    .add_enabled(can_save, egui::Button::new("Save Preview…"))
+                    .clicked()
+                {
+                    self.prompt_and_save();
+                }
+                if ui.button("Render Now").clicked() {
+                    let mode = if self.params.dry_run_mode {
+                        RenderMode::StatsOnly
+                    } else {
+                        RenderMode::Preview
+                    };
+                    if let Err(err) = self.schedule_render(mode) {
+                        self.set_error(err);
+                    }
+                }
+                ui.separator();
                 ui.heading("Film Grain Viewer");
                 ui.separator();
                 ui.label(self.top_bar_text());
                 ui.separator();
                 ui.label(self.worker_status.status_text());
             });
+            if let Some(err) = &self.last_error {
+                ui.colored_label(egui::Color32::LIGHT_RED, format!("Error: {err}"));
+            }
             if let Some(path) = &self.pending_save_path {
-                ui.label(format!("Pending save target: {}", path.display()));
+                ui.label(format!("Last saved: {}", path.display()));
             }
         });
 
         egui::SidePanel::left("controls")
             .resizable(false)
-            .min_width(260.0)
+            .min_width(280.0)
             .show(ctx, |ui| {
                 egui::ScrollArea::vertical().show(ui, |ui| {
-                    self.params.show(ui);
+                    let change = self.params.show(
+                        ui,
+                        self.source.as_ref(),
+                        self.worker_runtime.gpu_available(),
+                    );
+                    self.apply_param_change(change);
                     ui.separator();
+                    ui.heading("Last render stats");
                     if let Some(stats) = &self.last_stats {
-                        ui.heading("Last render stats");
                         ui.label(stats_summary(stats));
+                        if let Some(duration) = self.worker_status.last_duration() {
+                            ui.label(format!("Last run time: {:.2}s", duration.as_secs_f32()));
+                        }
                     } else {
-                        ui.heading("Last render stats");
                         ui.label("No render has completed yet.");
                     }
                 });
@@ -114,6 +149,11 @@ impl ViewerState {
                     if let Some(texture) = self.preview.texture.as_ref() {
                         let size = texture.size_vec2();
                         ui.image((texture.id(), size));
+                        ui.label(format!(
+                            "{} × {} px",
+                            size.x.round() as u32,
+                            size.y.round() as u32
+                        ));
                     } else {
                         ui.label("No preview yet – load an image to begin.");
                     }
@@ -129,13 +169,21 @@ impl ViewerState {
                 continue;
             }
             match result.outcome {
-                Ok(success) => {
-                    self.last_stats = Some(success.stats);
-                    self.preview.set_image(ctx, success.image);
+                Ok(JobResult::Preview { image, stats }) => {
+                    self.last_stats = Some(stats);
+                    self.preview.set_image(ctx, image);
                     self.worker_status.complete();
+                    self.clear_error();
+                }
+                Ok(JobResult::Stats { stats }) => {
+                    self.last_stats = Some(stats);
+                    self.worker_status.complete();
+                    self.clear_error();
                 }
                 Err(err) => {
-                    self.worker_status.fail(err.to_string());
+                    let message = err.to_string();
+                    self.worker_status.fail(message.clone());
+                    self.set_error(message);
                 }
             }
             updated = true;
@@ -159,42 +207,198 @@ impl ViewerState {
         }
     }
 
-    #[allow(dead_code)]
-    fn request_render(&mut self) -> Result<(), String> {
+    fn apply_param_change(&mut self, change: ParamChange) {
+        if !change.require_reload && !change.request_preview && !change.request_stats_only {
+            return;
+        }
+        if self.source.is_none() {
+            return;
+        }
+        if change.require_reload {
+            if let Err(err) = self.reload_source_from_params() {
+                self.set_error(err);
+                return;
+            }
+        }
+        if change.request_preview {
+            if let Err(err) = self.schedule_render(RenderMode::Preview) {
+                self.set_error(err);
+            }
+        } else if change.request_stats_only {
+            if let Err(err) = self.schedule_render(RenderMode::StatsOnly) {
+                self.set_error(err);
+            }
+        }
+    }
+
+    fn schedule_render(&mut self, mode: RenderMode) -> Result<(), String> {
         let source = self
             .source
             .as_ref()
-            .ok_or_else(|| "no source loaded".to_owned())?;
-        let builder = self.params.to_builder(source);
-        let params = builder.build().map_err(|err| err.to_string())?;
+            .ok_or_else(|| "no image loaded".to_owned())?;
+        let mut params = self
+            .params
+            .to_builder(source, matches!(mode, RenderMode::StatsOnly))
+            .build()
+            .map_err(|err| err.to_string())?;
+        if matches!(mode, RenderMode::StatsOnly) {
+            params.dry_run = true;
+        }
+        let kind = match mode {
+            RenderMode::Preview => RenderTaskKind::Preview,
+            RenderMode::StatsOnly => RenderTaskKind::StatsOnly,
+        };
         let job_id = self
             .worker_runtime
-            .request(source.cache.clone(), params)
-            .map_err(|err| err)?;
+            .request(source.cache.clone(), params, kind)?;
         self.worker_status.begin_render(job_id);
         Ok(())
+    }
+
+    fn reload_source_from_params(&mut self) -> Result<(), String> {
+        let source = self
+            .source
+            .as_mut()
+            .ok_or_else(|| "no image loaded".to_owned())?;
+        let roi = self.params.current_roi();
+        let cache = InputImage::from_path(&source.path, self.params.color_mode, roi.as_ref())
+            .map_err(|err| err.to_string())?;
+        let cache = Arc::new(cache);
+        source.set_cache(cache.clone());
+        self.params.sync_with_source(source);
+        self.preview.clear();
+        self.last_stats = None;
+        self.worker_status.reset();
+        Ok(())
+    }
+
+    fn prompt_and_load(&mut self) {
+        if let Some(path) = FileDialog::new()
+            .add_filter(
+                "Images",
+                &["png", "jpg", "jpeg", "tif", "tiff", "bmp", "hdr", "gif"],
+            )
+            .pick_file()
+        {
+            if let Err(err) = self.load_image_from_path(path.clone()) {
+                self.set_error(err);
+            } else {
+                self.pending_save_path = None;
+            }
+        }
+    }
+
+    fn load_image_from_path(&mut self, path: PathBuf) -> Result<(), String> {
+        let cache = InputImage::from_path(&path, self.params.color_mode, None)
+            .map_err(|err| err.to_string())?;
+        let cache = Arc::new(cache);
+        let source = SourceImage::new(path.clone(), cache.clone());
+        self.params.sync_with_source(&source);
+        self.params.update_output_defaults(&path);
+        self.source = Some(source);
+        self.preview.clear();
+        self.last_stats = None;
+        self.worker_status.reset();
+        self.clear_error();
+        let mode = if self.params.dry_run_mode {
+            RenderMode::StatsOnly
+        } else {
+            RenderMode::Preview
+        };
+        self.schedule_render(mode)?;
+        Ok(())
+    }
+
+    fn prompt_and_save(&mut self) {
+        let Some(image) = self.preview.latest_image() else {
+            self.set_error("no preview image available to save".to_owned());
+            return;
+        };
+        let default_name = self
+            .source
+            .as_ref()
+            .map(|source| self.params.resolve_output_path(&source.path))
+            .and_then(|path| {
+                path.file_name()
+                    .and_then(|s| s.to_str().map(|t| t.to_owned()))
+            })
+            .unwrap_or_else(|| "filmgrain.png".to_owned());
+        if let Some(path) = FileDialog::new()
+            .set_file_name(&default_name)
+            .add_filter("Images", &["png", "jpg", "jpeg", "tif", "tiff", "bmp"])
+            .save_file()
+        {
+            if let Err(err) = image.clone().save(&path) {
+                self.set_error(err.to_string());
+            } else {
+                self.pending_save_path = Some(path);
+                self.clear_error();
+            }
+        }
+    }
+
+    fn set_error(&mut self, message: String) {
+        self.last_error = Some(message);
+    }
+
+    fn clear_error(&mut self) {
+        self.last_error = None;
     }
 }
 
 struct SourceImage {
     path: PathBuf,
-    cache: InputImage,
+    cache: Arc<InputImage>,
     width: usize,
     height: usize,
+}
+
+impl SourceImage {
+    fn new(path: PathBuf, cache: Arc<InputImage>) -> Self {
+        let (width, height) = cache.dimensions();
+        Self {
+            path,
+            cache,
+            width,
+            height,
+        }
+    }
+
+    fn set_cache(&mut self, cache: Arc<InputImage>) {
+        let (width, height) = cache.dimensions();
+        self.cache = cache;
+        self.width = width;
+        self.height = height;
+    }
 }
 
 #[derive(Default)]
 struct PreviewState {
     texture: Option<egui::TextureHandle>,
     generation: u64,
+    last_image: Option<RgbImage>,
 }
 
 impl PreviewState {
     fn set_image(&mut self, ctx: &egui::Context, image: RgbImage) {
+        self.last_image = Some(image.clone());
         let color_image = color_image_from_rgb(image);
         let name = format!("filmgrain-preview-{}", self.generation);
         self.generation = self.generation.wrapping_add(1);
         self.texture = Some(ctx.load_texture(name, color_image, egui::TextureOptions::default()));
+    }
+
+    fn has_image(&self) -> bool {
+        self.last_image.is_some()
+    }
+
+    fn latest_image(&self) -> Option<&RgbImage> {
+        self.last_image.as_ref()
+    }
+
+    fn clear(&mut self) {
+        self.texture = None;
+        self.last_image = None;
     }
 }
 
@@ -207,16 +411,24 @@ struct InteractiveParams {
     n_samples: u32,
     algo: Algo,
     max_radius: MaxRadius,
-    cell_delta: Option<f32>,
+    cell_auto: bool,
+    cell_value: f32,
     color_mode: ColorMode,
-    roi: Option<Roi>,
-    size: Option<(u32, Option<u32>)>,
+    roi_enabled: bool,
+    roi_x0: u32,
+    roi_y0: u32,
+    roi_x1: u32,
+    roi_y1: u32,
+    size_enabled: bool,
+    size_width: u32,
+    size_height_enabled: bool,
+    size_height: u32,
     seed: u64,
-    dry_run: bool,
+    dry_run_mode: bool,
     explain: bool,
     device: Device,
-    output_path: Option<PathBuf>,
-    output_format: Option<String>,
+    output_path_override: String,
+    output_format_override: String,
 }
 
 impl Default for InteractiveParams {
@@ -230,28 +442,33 @@ impl Default for InteractiveParams {
             n_samples: 32,
             algo: Algo::Auto,
             max_radius: MaxRadius::Quantile(0.999),
-            cell_delta: None,
+            cell_auto: true,
+            cell_value: 0.1,
             color_mode: ColorMode::Luma,
-            roi: None,
-            size: None,
+            roi_enabled: false,
+            roi_x0: 0,
+            roi_y0: 0,
+            roi_x1: 1,
+            roi_y1: 1,
+            size_enabled: false,
+            size_width: 1,
+            size_height_enabled: false,
+            size_height: 1,
             seed: 5489,
-            dry_run: false,
+            dry_run_mode: false,
             explain: false,
             device: Device::Cpu,
-            output_path: None,
-            output_format: None,
+            output_path_override: String::new(),
+            output_format_override: String::new(),
         }
     }
 }
 
 impl InteractiveParams {
-    fn to_builder(&self, source: &SourceImage) -> ParamsBuilder {
+    fn to_builder(&self, source: &SourceImage, dry_run: bool) -> ParamsBuilder {
         ParamsBuilder {
             input_path: source.path.clone(),
-            output_path: self
-                .output_path
-                .clone()
-                .unwrap_or_else(|| default_output_path(&source.path)),
+            output_path: self.resolve_output_path(&source.path),
             radius_dist: self.radius_dist,
             radius_mean: self.radius_mean,
             radius_stddev: self.radius_stddev,
@@ -260,62 +477,494 @@ impl InteractiveParams {
             n_samples: self.n_samples,
             algo: self.algo,
             max_radius: self.max_radius,
-            cell_delta: self.cell_delta,
+            cell_delta: self.current_cell_delta(),
             color_mode: self.color_mode,
-            roi: self.roi,
-            size: self.size,
+            roi: self.current_roi(),
+            size: self.current_size_override(),
             seed: self.seed,
-            dry_run: self.dry_run,
+            dry_run,
             explain: self.explain,
             device: self.device,
-            output_format: self.output_format.clone(),
+            output_format: {
+                let trimmed = self.output_format_override.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_owned())
+                }
+            },
         }
     }
 
-    fn show(&self, ui: &mut egui::Ui) {
-        ui.label(format!("Radius distribution: {:?}", self.radius_dist));
-        ui.label(format!("Radius mean: {:.3}", self.radius_mean));
-        ui.label(format!("Radius stddev: {:.3}", self.radius_stddev));
-        ui.label(format!("Zoom: {:.3}", self.zoom));
-        ui.label(format!("Sigma (px): {:.3}", self.sigma_px));
-        ui.label(format!("Samples: {}", self.n_samples));
-        ui.label(format!("Algorithm: {:?}", self.algo));
-        ui.label(format!("Device: {:?}", self.device));
-        ui.label(format!(
-            "Max radius: {}",
-            match self.max_radius {
-                MaxRadius::Absolute(v) => format!("absolute {:.3}", v),
-                MaxRadius::Quantile(q) => format!("quantile {:.3}", q),
+    fn show(
+        &mut self,
+        ui: &mut egui::Ui,
+        source: Option<&SourceImage>,
+        gpu_available: bool,
+    ) -> ParamChange {
+        let mut change = ParamChange::new(self.dry_run_mode);
+
+        ui.heading("Model");
+        if ui
+            .add(
+                egui::Slider::new(&mut self.radius_mean, 0.01..=5.0)
+                    .logarithmic(true)
+                    .text("Mean radius (px)"),
+            )
+            .changed()
+        {
+            if self.cell_auto {
+                self.cell_value = default_cell_delta(self.radius_mean);
             }
-        ));
-        ui.label(format!(
-            "Cell delta: {}",
-            self.cell_delta
-                .map(|d| format!("{:.3}", d))
-                .unwrap_or_else(|| "auto".to_owned())
-        ));
-        ui.label(format!("Color mode: {:?}", self.color_mode));
-        if let Some(roi) = self.roi {
-            ui.label(format!("ROI: {} {} {} {}", roi.x0, roi.y0, roi.x1, roi.y1));
-        } else {
-            ui.label("ROI: full image");
+            change.mark_changed();
         }
-        if let Some((width, maybe_height)) = self.size {
-            let text = maybe_height
-                .map(|h| format!("{} × {}", width, h))
-                .unwrap_or_else(|| format!("width {}", width));
-            ui.label(format!("Output size override: {text}"));
-        } else {
-            ui.label("Output size override: none");
+
+        let radius_before = self.radius_dist;
+        egui::ComboBox::from_label("Radius distribution")
+            .selected_text(match self.radius_dist {
+                RadiusDist::Const => "Const",
+                RadiusDist::Lognorm => "Log-normal",
+            })
+            .show_ui(ui, |ui| {
+                ui.selectable_value(&mut self.radius_dist, RadiusDist::Const, "Const");
+                ui.selectable_value(&mut self.radius_dist, RadiusDist::Lognorm, "Log-normal");
+            });
+        if self.radius_dist != radius_before {
+            if self.radius_dist == RadiusDist::Const {
+                self.radius_stddev = 0.0;
+            }
+            change.mark_changed();
         }
-        ui.label(format!("Seed: {}", self.seed));
-        ui.label(format!("Dry run: {}", self.dry_run));
-        ui.label(format!("Explain: {}", self.explain));
-        if let Some(fmt) = &self.output_format {
-            ui.label(format!("Output format override: {fmt}"));
-        } else {
-            ui.label("Output format override: auto from path");
+
+        if ui
+            .add_enabled(
+                matches!(self.radius_dist, RadiusDist::Lognorm),
+                egui::Slider::new(&mut self.radius_stddev, 0.0..=2.0)
+                    .text("Radius stddev (px)")
+                    .logarithmic(true),
+            )
+            .changed()
+        {
+            change.mark_changed();
         }
+
+        ui.separator();
+        ui.heading("Sampling");
+        if ui
+            .add(egui::Slider::new(&mut self.zoom, 0.25..=4.0).text("Zoom (output scale)"))
+            .changed()
+        {
+            change.mark_changed();
+        }
+        if ui
+            .add(
+                egui::Slider::new(&mut self.sigma_px, 0.1..=5.0)
+                    .logarithmic(true)
+                    .text("Sigma (px)"),
+            )
+            .changed()
+        {
+            change.mark_changed();
+        }
+        if ui
+            .add(
+                egui::Slider::new(&mut self.n_samples, 1..=512)
+                    .text("Samples")
+                    .logarithmic(true),
+            )
+            .changed()
+        {
+            change.mark_changed();
+        }
+
+        ui.separator();
+        ui.heading("Algorithm");
+        let algo_before = self.algo;
+        egui::ComboBox::from_label("Algorithm override")
+            .selected_text(format!("{:?}", self.algo))
+            .show_ui(ui, |ui| {
+                ui.selectable_value(&mut self.algo, Algo::Auto, "Auto");
+                ui.selectable_value(&mut self.algo, Algo::Pixel, "Pixel-wise");
+                ui.selectable_value(&mut self.algo, Algo::Grain, "Grain-wise");
+            });
+        if self.algo != algo_before {
+            change.mark_changed();
+        }
+
+        enum MaxSetting {
+            Absolute(f32),
+            Quantile(f32),
+        }
+        let mut max_setting = match self.max_radius {
+            MaxRadius::Absolute(value) => MaxSetting::Absolute(value),
+            MaxRadius::Quantile(prob) => MaxSetting::Quantile(prob),
+        };
+        let mut max_changed = false;
+        let mut new_setting: Option<MaxSetting> = None;
+        match &mut max_setting {
+            MaxSetting::Absolute(value) => {
+                ui.horizontal(|ui| {
+                    ui.label("Max radius (absolute)");
+                    max_changed |= ui
+                        .add(egui::DragValue::new(value).range(0.01..=10.0).speed(0.05))
+                        .changed();
+                    if ui.button("Switch to quantile").clicked() {
+                        new_setting = Some(MaxSetting::Quantile(0.999));
+                    }
+                });
+            }
+            MaxSetting::Quantile(prob) => {
+                ui.horizontal(|ui| {
+                    ui.label("Max radius quantile");
+                    max_changed |= ui
+                        .add(
+                            egui::Slider::new(prob, 0.5..=0.99999)
+                                .logarithmic(true)
+                                .text("Quantile"),
+                        )
+                        .changed();
+                    if ui.button("Switch to absolute").clicked() {
+                        new_setting = Some(MaxSetting::Absolute(1.0));
+                    }
+                });
+            }
+        }
+        if let Some(setting) = new_setting {
+            max_setting = setting;
+            max_changed = true;
+        }
+        if max_changed {
+            self.max_radius = match max_setting {
+                MaxSetting::Absolute(value) => MaxRadius::Absolute(value.max(0.01)),
+                MaxSetting::Quantile(prob) => MaxRadius::Quantile(prob.clamp(0.5, 0.99999)),
+            };
+            change.mark_changed();
+        }
+
+        ui.separator();
+        ui.heading("Cell size");
+        let cell_auto_prev = self.cell_auto;
+        if ui
+            .checkbox(&mut self.cell_auto, "Automatic (≈ μᵣ)")
+            .changed()
+        {
+            if self.cell_auto {
+                self.cell_value = default_cell_delta(self.radius_mean);
+            }
+            change.mark_changed();
+        }
+        if !self.cell_auto {
+            if ui
+                .add(
+                    egui::Slider::new(&mut self.cell_value, 0.01..=5.0)
+                        .logarithmic(true)
+                        .text("Manual cell size"),
+                )
+                .changed()
+            {
+                change.mark_changed();
+            }
+        }
+        if cell_auto_prev && !self.cell_auto {
+            change.mark_changed();
+        }
+
+        ui.separator();
+        ui.heading("Colour & ROI");
+        let color_before = self.color_mode;
+        egui::ComboBox::from_label("Colour mode")
+            .selected_text(match self.color_mode {
+                ColorMode::Luma => "Luma (Y only)",
+                ColorMode::Rgb => "RGB (per channel)",
+            })
+            .show_ui(ui, |ui| {
+                ui.selectable_value(&mut self.color_mode, ColorMode::Luma, "Luma (Y only)");
+                ui.selectable_value(&mut self.color_mode, ColorMode::Rgb, "RGB (per channel)");
+            });
+        if self.color_mode != color_before {
+            change.mark_reload();
+        }
+
+        ui.collapsing("Region of interest", |ui| {
+            if ui.checkbox(&mut self.roi_enabled, "Enable ROI").changed() {
+                change.mark_reload();
+            }
+            if self.roi_enabled {
+                let mut roi_changed = false;
+                roi_changed |= ui
+                    .add(
+                        egui::DragValue::new(&mut self.roi_x0)
+                            .range(0..=u32::MAX)
+                            .prefix("x₀ "),
+                    )
+                    .changed();
+                roi_changed |= ui
+                    .add(
+                        egui::DragValue::new(&mut self.roi_y0)
+                            .range(0..=u32::MAX)
+                            .prefix("y₀ "),
+                    )
+                    .changed();
+                roi_changed |= ui
+                    .add(
+                        egui::DragValue::new(&mut self.roi_x1)
+                            .range(1..=u32::MAX)
+                            .prefix("x₁ "),
+                    )
+                    .changed();
+                roi_changed |= ui
+                    .add(
+                        egui::DragValue::new(&mut self.roi_y1)
+                            .range(1..=u32::MAX)
+                            .prefix("y₁ "),
+                    )
+                    .changed();
+                if roi_changed {
+                    change.mark_reload();
+                }
+                if let Some(source) = source {
+                    self.clamp_roi_to_source(source);
+                }
+            }
+        });
+
+        ui.separator();
+        ui.heading("Output size");
+        if ui
+            .checkbox(&mut self.size_enabled, "Override output size")
+            .changed()
+        {
+            change.mark_changed();
+        }
+        if self.size_enabled {
+            if ui
+                .add(
+                    egui::DragValue::new(&mut self.size_width)
+                        .range(1..=16384)
+                        .prefix("Width "),
+                )
+                .changed()
+            {
+                change.mark_changed();
+            }
+            if ui
+                .checkbox(&mut self.size_height_enabled, "Set explicit height")
+                .changed()
+            {
+                change.mark_changed();
+            }
+            if self.size_height_enabled
+                && ui
+                    .add(
+                        egui::DragValue::new(&mut self.size_height)
+                            .range(1..=16384)
+                            .prefix("Height "),
+                    )
+                    .changed()
+            {
+                change.mark_changed();
+            }
+        }
+
+        ui.separator();
+        ui.heading("Rendering");
+        let device_before = self.device;
+        egui::ComboBox::from_label("Device")
+            .selected_text(match self.device {
+                Device::Cpu => "CPU",
+                Device::Gpu => "GPU",
+            })
+            .show_ui(ui, |ui| {
+                ui.selectable_value(&mut self.device, Device::Cpu, "CPU");
+                ui.add_enabled_ui(gpu_available, |ui| {
+                    ui.selectable_value(&mut self.device, Device::Gpu, "GPU");
+                });
+            });
+        if !gpu_available && self.device == Device::Gpu {
+            self.device = Device::Cpu;
+        }
+        if self.device != device_before {
+            change.mark_changed();
+        }
+        if ui.button("Reset device to CPU").clicked() {
+            self.device = Device::Cpu;
+            change.mark_changed();
+        }
+        if ui
+            .checkbox(&mut self.dry_run_mode, "Dry run (stats only)")
+            .changed()
+        {
+            change.mark_mode_switch(self.dry_run_mode);
+        }
+        if ui
+            .checkbox(&mut self.explain, "Explain selection")
+            .changed()
+        {
+            change.mark_changed();
+        }
+
+        ui.separator();
+        ui.heading("Randomness");
+        let mut seed_changed = false;
+        seed_changed |= ui
+            .add(
+                egui::DragValue::new(&mut self.seed)
+                    .range(1..=u64::MAX)
+                    .speed(64.0)
+                    .prefix("Seed "),
+            )
+            .changed();
+        if ui.button("Randomise").clicked() {
+            self.seed = rand::thread_rng().r#gen::<u64>();
+            seed_changed = true;
+        }
+        if seed_changed {
+            change.mark_changed();
+        }
+
+        ui.separator();
+        ui.heading("Output");
+        if ui
+            .text_edit_singleline(&mut self.output_path_override)
+            .changed()
+        {
+            // Changing output path does not require a re-render.
+        }
+        if ui
+            .text_edit_singleline(&mut self.output_format_override)
+            .changed()
+        {
+            // Format change affects only export.
+        }
+
+        change
+    }
+
+    fn resolve_output_path(&self, source_path: &Path) -> PathBuf {
+        let trimmed = self.output_path_override.trim();
+        if trimmed.is_empty() {
+            default_output_path(source_path)
+        } else {
+            PathBuf::from(trimmed)
+        }
+    }
+
+    fn current_cell_delta(&self) -> Option<f32> {
+        if self.cell_auto {
+            None
+        } else {
+            Some(self.cell_value.max(0.0001))
+        }
+    }
+
+    fn current_roi(&self) -> Option<Roi> {
+        if self.roi_enabled && self.roi_x1 > self.roi_x0 && self.roi_y1 > self.roi_y0 {
+            Some(Roi {
+                x0: self.roi_x0,
+                y0: self.roi_y0,
+                x1: self.roi_x1,
+                y1: self.roi_y1,
+            })
+        } else {
+            None
+        }
+    }
+
+    fn current_size_override(&self) -> Option<(u32, Option<u32>)> {
+        if !self.size_enabled {
+            return None;
+        }
+        let width = self.size_width.max(1);
+        let height_opt = if self.size_height_enabled {
+            Some(self.size_height.max(1))
+        } else {
+            None
+        };
+        Some((width, height_opt))
+    }
+
+    fn sync_with_source(&mut self, source: &SourceImage) {
+        let max_width = source.width.max(1) as u32;
+        let max_height = source.height.max(1) as u32;
+        if !self.roi_enabled {
+            self.roi_x0 = 0;
+            self.roi_y0 = 0;
+            self.roi_x1 = max_width;
+            self.roi_y1 = max_height;
+        } else {
+            self.roi_x0 = self.roi_x0.min(max_width.saturating_sub(1));
+            self.roi_y0 = self.roi_y0.min(max_height.saturating_sub(1));
+            self.roi_x1 = self.roi_x1.clamp(self.roi_x0 + 1, max_width);
+            self.roi_y1 = self.roi_y1.clamp(self.roi_y0 + 1, max_height);
+        }
+        if !self.size_enabled {
+            self.size_width = max_width;
+            self.size_height = max_height;
+        } else {
+            self.size_width = self.size_width.max(1);
+            if self.size_height_enabled {
+                self.size_height = self.size_height.max(1);
+            }
+        }
+        if self.cell_auto {
+            self.cell_value = default_cell_delta(self.radius_mean);
+        }
+    }
+
+    fn clamp_roi_to_source(&mut self, source: &SourceImage) {
+        let max_width = source.width.max(1) as u32;
+        let max_height = source.height.max(1) as u32;
+        self.roi_x0 = self.roi_x0.min(max_width.saturating_sub(1));
+        self.roi_y0 = self.roi_y0.min(max_height.saturating_sub(1));
+        self.roi_x1 = self.roi_x1.clamp(self.roi_x0 + 1, max_width);
+        self.roi_y1 = self.roi_y1.clamp(self.roi_y0 + 1, max_height);
+    }
+
+    fn update_output_defaults(&mut self, source_path: &Path) {
+        if self.output_path_override.trim().is_empty() {
+            if let Some(path) = default_output_path(source_path).to_str() {
+                self.output_path_override = path.to_owned();
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct ParamChange {
+    request_preview: bool,
+    request_stats_only: bool,
+    require_reload: bool,
+    dry_run_mode: bool,
+}
+
+impl ParamChange {
+    fn new(dry_run_mode: bool) -> Self {
+        Self {
+            request_preview: false,
+            request_stats_only: false,
+            require_reload: false,
+            dry_run_mode,
+        }
+    }
+
+    fn mark_changed(&mut self) {
+        if self.dry_run_mode {
+            self.request_stats_only = true;
+            self.request_preview = false;
+        } else {
+            self.request_preview = true;
+            self.request_stats_only = false;
+        }
+    }
+
+    fn mark_reload(&mut self) {
+        self.require_reload = true;
+        self.mark_changed();
+    }
+
+    fn mark_mode_switch(&mut self, dry_run_mode: bool) {
+        self.dry_run_mode = dry_run_mode;
+        self.mark_changed();
     }
 }
 
@@ -324,6 +973,7 @@ struct RenderWorker {
     result_rx: mpsc::Receiver<RenderOutcome>,
     latest_request: Arc<AtomicU64>,
     next_job_id: u64,
+    gpu_available: bool,
 }
 
 impl RenderWorker {
@@ -332,6 +982,8 @@ impl RenderWorker {
         let (result_tx, result_rx) = mpsc::channel::<RenderOutcome>();
         let latest_request = Arc::new(AtomicU64::new(0));
         let worker_latest = latest_request.clone();
+        let gpu_available = film_grain::wgpu::context().is_ok();
+
         thread::Builder::new()
             .name("film-grain-render".into())
             .spawn(move || {
@@ -340,8 +992,16 @@ impl RenderWorker {
                     if job.id != current {
                         continue;
                     }
-                    let outcome = render_with_input_image(&job.input, &job.params)
-                        .map(|(image, stats)| RenderSuccess { image, stats });
+                    let outcome = match job.kind {
+                        RenderTaskKind::Preview => {
+                            render_with_input_image(job.input.as_ref(), &job.params)
+                                .map(|(image, stats)| JobResult::Preview { image, stats })
+                        }
+                        RenderTaskKind::StatsOnly => {
+                            let stats = dry_run_with_input_image(job.input.as_ref(), &job.params);
+                            stats.map(|stats| JobResult::Stats { stats })
+                        }
+                    };
                     if job.id != worker_latest.load(Ordering::SeqCst) {
                         continue;
                     }
@@ -363,17 +1023,28 @@ impl RenderWorker {
             result_rx,
             latest_request,
             next_job_id: 1,
+            gpu_available,
         }
     }
 
-    fn request(&mut self, input: InputImage, params: Params) -> Result<u64, String> {
+    fn request(
+        &mut self,
+        input: Arc<InputImage>,
+        params: Params,
+        kind: RenderTaskKind,
+    ) -> Result<u64, String> {
         let id = self.next_job_id;
         self.next_job_id = self.next_job_id.wrapping_add(1);
         if self.next_job_id == 0 {
             self.next_job_id = 1;
         }
         self.latest_request.store(id, Ordering::SeqCst);
-        let job = RenderJob { id, input, params };
+        let job = RenderJob {
+            id,
+            input,
+            params,
+            kind,
+        };
         self.job_tx.send(job).map_err(|err| err.to_string())?;
         Ok(id)
     }
@@ -381,22 +1052,39 @@ impl RenderWorker {
     fn try_recv(&self) -> Option<RenderOutcome> {
         self.result_rx.try_recv().ok()
     }
+
+    fn gpu_available(&self) -> bool {
+        self.gpu_available
+    }
 }
 
 struct RenderJob {
     id: u64,
-    input: InputImage,
+    input: Arc<InputImage>,
     params: Params,
+    kind: RenderTaskKind,
 }
 
 struct RenderOutcome {
     id: u64,
-    outcome: Result<RenderSuccess, RenderError>,
+    outcome: Result<JobResult, RenderError>,
 }
 
-struct RenderSuccess {
-    image: RgbImage,
-    stats: RenderStats,
+enum JobResult {
+    Preview { image: RgbImage, stats: RenderStats },
+    Stats { stats: RenderStats },
+}
+
+#[derive(Copy, Clone)]
+enum RenderMode {
+    Preview,
+    StatsOnly,
+}
+
+#[derive(Copy, Clone)]
+enum RenderTaskKind {
+    Preview,
+    StatsOnly,
 }
 
 fn color_image_from_rgb(image: RgbImage) -> egui::ColorImage {
@@ -413,10 +1101,20 @@ fn color_image_from_rgb(image: RgbImage) -> egui::ColorImage {
     }
 }
 
-#[derive(Default)]
 struct WorkerState {
     status: WorkerStatus,
     active_job: Option<u64>,
+    last_duration: Option<Duration>,
+}
+
+impl Default for WorkerState {
+    fn default() -> Self {
+        Self {
+            status: WorkerStatus::Idle,
+            active_job: None,
+            last_duration: None,
+        }
+    }
 }
 
 impl WorkerState {
@@ -424,10 +1122,22 @@ impl WorkerState {
         match &self.status {
             WorkerStatus::Idle => "idle".to_owned(),
             WorkerStatus::Rendering { started_at } => {
-                format!("rendering (started {}s ago)", elapsed_seconds(*started_at))
+                format!(
+                    "rendering ({:.2}s elapsed)",
+                    started_at.elapsed().as_secs_f32()
+                )
             }
             WorkerStatus::Completed { finished_at } => {
-                format!("completed {}s ago", elapsed_seconds(*finished_at))
+                let ago = finished_at.elapsed().as_secs_f32();
+                if let Some(duration) = self.last_duration {
+                    format!(
+                        "completed {:.2}s ago (took {:.2}s)",
+                        ago,
+                        duration.as_secs_f32()
+                    )
+                } else {
+                    format!("completed {:.2}s ago", ago)
+                }
             }
             WorkerStatus::Failed { message } => format!("failed: {message}"),
         }
@@ -438,9 +1148,13 @@ impl WorkerState {
         self.status = WorkerStatus::Rendering {
             started_at: Instant::now(),
         };
+        self.last_duration = None;
     }
 
     fn complete(&mut self) {
+        if let WorkerStatus::Rendering { started_at } = self.status {
+            self.last_duration = Some(started_at.elapsed());
+        }
         self.active_job = None;
         self.status = WorkerStatus::Completed {
             finished_at: Instant::now(),
@@ -448,13 +1162,21 @@ impl WorkerState {
     }
 
     fn fail(&mut self, message: String) {
+        if let WorkerStatus::Rendering { started_at } = self.status {
+            self.last_duration = Some(started_at.elapsed());
+        }
         self.active_job = None;
         self.status = WorkerStatus::Failed { message };
     }
 
-    #[allow(dead_code)]
-    fn is_busy(&self) -> bool {
-        matches!(self.status, WorkerStatus::Rendering { .. })
+    fn reset(&mut self) {
+        self.active_job = None;
+        self.status = WorkerStatus::Idle;
+        self.last_duration = None;
+    }
+
+    fn last_duration(&self) -> Option<Duration> {
+        self.last_duration
     }
 }
 
@@ -469,10 +1191,6 @@ impl Default for WorkerStatus {
     fn default() -> Self {
         WorkerStatus::Idle
     }
-}
-
-fn elapsed_seconds(instant: Instant) -> u64 {
-    instant.elapsed().as_secs()
 }
 
 fn stats_summary(stats: &RenderStats) -> String {

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,6 +1,4 @@
-use std::path::Path;
-
-use image::{DynamicImage, GenericImageView, ImageFormat, RgbImage};
+use image::{DynamicImage, GenericImageView, RgbImage};
 
 use crate::RenderError;
 use crate::model::Plane;
@@ -57,7 +55,7 @@ impl Workspace {
         Ok(())
     }
 
-    pub fn save(self, output_path: &Path, format: ImageFormat) -> Result<(), RenderError> {
+    pub fn into_rgb_image(self) -> Result<RgbImage, RenderError> {
         match self.kind {
             WorkspaceKind::Luma { y, cb, cr } => {
                 let width = y.width;
@@ -86,9 +84,8 @@ impl Workspace {
                         buffer[idx + 2] = to_u8(b);
                     }
                 }
-                let image = RgbImage::from_vec(width as u32, height as u32, buffer)
-                    .ok_or_else(|| RenderError::Message("failed to create RGB image".into()))?;
-                save_image(image, output_path, format)
+                RgbImage::from_vec(width as u32, height as u32, buffer)
+                    .ok_or_else(|| RenderError::Message("failed to create RGB image".into()))
             }
             WorkspaceKind::Rgb { planes } => {
                 let width = planes[0].width;
@@ -102,9 +99,8 @@ impl Workspace {
                         buffer[idx + 2] = to_u8(planes[2].get(x_idx, y_idx));
                     }
                 }
-                let image = RgbImage::from_vec(width as u32, height as u32, buffer)
-                    .ok_or_else(|| RenderError::Message("failed to create RGB image".into()))?;
-                save_image(image, output_path, format)
+                RgbImage::from_vec(width as u32, height as u32, buffer)
+                    .ok_or_else(|| RenderError::Message("failed to create RGB image".into()))
             }
         }
     }
@@ -191,10 +187,4 @@ fn clamp01(value: f32) -> f32 {
 
 fn to_u8(value: f32) -> u8 {
     (clamp01(value) * 255.0 + 0.5).floor() as u8
-}
-
-fn save_image(image: RgbImage, path: &Path, format: ImageFormat) -> Result<(), RenderError> {
-    image
-        .save_with_format(path, format)
-        .map_err(RenderError::from)
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -16,6 +16,7 @@ pub struct Workspace {
     kind: WorkspaceKind,
 }
 
+#[derive(Clone)]
 enum WorkspaceKind {
     Luma { y: Plane, cb: Plane, cr: Plane },
     Rgb { planes: [Plane; 3] },
@@ -113,6 +114,7 @@ impl Workspace {
     }
 }
 
+#[derive(Clone)]
 pub struct InputImage {
     color_mode: ColorMode,
     kind: WorkspaceKind,

--- a/src/grainwise.rs
+++ b/src/grainwise.rs
@@ -7,8 +7,14 @@ use rayon::prelude::*;
 use crate::model::{Derived, Plane};
 use crate::params::Params;
 use crate::rng;
+use crate::{RenderError, RenderResult};
 
-pub fn render_grainwise(lambda: &Plane, params: &Params, derived: &Derived) -> Plane {
+pub fn render_grainwise(
+    lambda: &Plane,
+    params: &Params,
+    derived: &Derived,
+    cancel: Option<&(dyn Fn() -> bool + Send + Sync)>,
+) -> RenderResult<Plane> {
     let out_w = derived.output_width;
     let out_h = derived.output_height;
     let total = out_w * out_h;
@@ -18,69 +24,94 @@ pub fn render_grainwise(lambda: &Plane, params: &Params, derived: &Derived) -> P
     let offsets = &derived.offsets;
     let zoom = params.zoom;
 
-    (0..derived.input_height).into_par_iter().for_each(|y| {
-        for x in 0..derived.input_width {
-            let lambda_val = lambda.get(x, y);
-            if lambda_val <= 0.0 {
-                continue;
+    let inv_samples = 1.0 / params.n_samples.max(1) as f32;
+    let cancel = cancel;
+    let render_result: Result<(), RenderError> =
+        (0..derived.input_height).into_par_iter().try_for_each(|y| {
+            if cancel.map_or(false, |check| check()) {
+                return Err(RenderError::Cancelled);
             }
-            let mut rng = rng::pixel_rng(params.seed, x as i32, y as i32);
-            let poisson = Poisson::new(lambda_val as f64).unwrap();
-            let q = poisson.sample(&mut rng) as u32;
-            if q == 0 {
-                continue;
-            }
-            let uniform = Uniform::new(0.0f32, 1.0);
-            for _ in 0..q {
-                let cx = x as f32 + uniform.sample(&mut rng);
-                let cy = y as f32 + uniform.sample(&mut rng);
-                let mut radius = derived.radius.sample(&mut rng);
-                if radius > derived.rm {
-                    radius = derived.rm;
+            for x in 0..derived.input_width {
+                if cancel.map_or(false, |check| check()) {
+                    return Err(RenderError::Cancelled);
                 }
-                if radius <= 0.0 {
+                let lambda_val = lambda.get(x, y);
+                if lambda_val <= 0.0 {
                     continue;
                 }
-                let radius_out = radius * zoom;
-                if radius_out <= 0.0 {
+                let mut rng = rng::pixel_rng(params.seed, x as i32, y as i32);
+                let poisson = Poisson::new(lambda_val as f64).unwrap();
+                let q = poisson.sample(&mut rng) as u32;
+                if q == 0 {
                     continue;
                 }
-                let radius_sq = radius_out * radius_out;
-                for (k, offset) in offsets.iter().enumerate() {
-                    let tx = (cx * zoom) + offset[0];
-                    let ty = (cy * zoom) + offset[1];
-                    if let Some((x_min, x_max)) =
-                        bounds(tx, radius_out, derived.output_width as i32)
-                        && let Some((y_min, y_max)) =
-                            bounds(ty, radius_out, derived.output_height as i32)
-                    {
-                        let lane_idx = k / 64;
-                        let bit_mask = 1u64 << (k % 64);
+                let uniform = Uniform::new(0.0f32, 1.0);
+                for _ in 0..q {
+                    if cancel.map_or(false, |check| check()) {
+                        return Err(RenderError::Cancelled);
+                    }
+                    let cx = x as f32 + uniform.sample(&mut rng);
+                    let cy = y as f32 + uniform.sample(&mut rng);
+                    let mut radius = derived.radius.sample(&mut rng);
+                    if radius > derived.rm {
+                        radius = derived.rm;
+                    }
+                    if radius <= 0.0 {
+                        continue;
+                    }
+                    let radius_out = radius * zoom;
+                    if radius_out <= 0.0 {
+                        continue;
+                    }
+                    let radius_sq = radius_out * radius_out;
+                    for (k, offset) in offsets.iter().enumerate() {
+                        if cancel.map_or(false, |check| check()) {
+                            return Err(RenderError::Cancelled);
+                        }
+                        let tx = (cx * zoom) + offset[0];
+                        let ty = (cy * zoom) + offset[1];
+                        if let Some((x_min, x_max)) =
+                            bounds(tx, radius_out, derived.output_width as i32)
+                            && let Some((y_min, y_max)) =
+                                bounds(ty, radius_out, derived.output_height as i32)
+                        {
+                            let lane_idx = k / 64;
+                            let bit_mask = 1u64 << (k % 64);
 
-                        for oy in y_min..=y_max {
-                            let center_y = oy as f32 + 0.5;
-                            let dy = center_y - ty;
-                            let dy_sq = dy * dy;
-                            if dy_sq > radius_sq {
-                                continue;
-                            }
-                            for ox in x_min..=x_max {
-                                let center_x = ox as f32 + 0.5;
-                                let dx = center_x - tx;
-                                if dx * dx + dy_sq <= radius_sq {
-                                    let idx = oy as usize * derived.output_width + ox as usize;
-                                    let slot = idx * lanes + lane_idx;
-                                    bitsets[slot].fetch_or(bit_mask, Ordering::Relaxed);
+                            for oy in y_min..=y_max {
+                                if cancel.map_or(false, |check| check()) {
+                                    return Err(RenderError::Cancelled);
+                                }
+                                let center_y = oy as f32 + 0.5;
+                                let dy = center_y - ty;
+                                let dy_sq = dy * dy;
+                                if dy_sq > radius_sq {
+                                    continue;
+                                }
+                                for ox in x_min..=x_max {
+                                    if cancel.map_or(false, |check| check()) {
+                                        return Err(RenderError::Cancelled);
+                                    }
+                                    let center_x = ox as f32 + 0.5;
+                                    let dx = center_x - tx;
+                                    if dx * dx + dy_sq <= radius_sq {
+                                        let idx = oy as usize * derived.output_width + ox as usize;
+                                        let slot = idx * lanes + lane_idx;
+                                        bitsets[slot].fetch_or(bit_mask, Ordering::Relaxed);
+                                    }
                                 }
                             }
                         }
                     }
                 }
             }
-        }
-    });
+            Ok(())
+        });
+    render_result?;
 
-    let inv_samples = 1.0 / params.n_samples.max(1) as f32;
+    if cancel.map_or(false, |check| check()) {
+        return Err(RenderError::Cancelled);
+    }
     let mut data = vec![0.0f32; total];
     for (pixel_idx, value) in data.iter_mut().enumerate() {
         let mut count = 0u32;
@@ -90,7 +121,7 @@ pub fn render_grainwise(lambda: &Plane, params: &Params, derived: &Derived) -> P
         }
         *value = count as f32 * inv_samples;
     }
-    Plane::from_vec(out_w, out_h, data)
+    Ok(Plane::from_vec(out_w, out_h, data))
 }
 
 fn bounds(center: f32, radius: f32, limit: i32) -> Option<(i32, i32)> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,8 @@ pub mod wgpu;
 
 pub use color::InputImage;
 pub use params::{
-    Algo, CliArgs, ColorMode, Device, MaxRadius, Params, ParamsError, ParamsResult, RadiusDist,
-    Roi, build_params, default_cell_delta,
+    Algo, CliArgs, ColorMode, Device, MaxRadius, Params, ParamsBuilder, ParamsError, ParamsResult,
+    RadiusDist, Roi, build_params, default_cell_delta,
 };
 
 pub type RenderResult<T> = Result<T, RenderError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,12 +153,12 @@ fn render_from_workspace_impl(
             (Device::Cpu, Algo::Grain) => render_grainwise(&lambda, params, &derived, cancel),
             (Device::Gpu, Algo::Pixel) => {
                 check_cancel(cancel)?;
-                let ctx = gpu_ctx.expect("gpu context initialized");
+                let ctx = gpu_ctx.as_ref().expect("gpu context initialized").as_ref();
                 wgpu::render_pixelwise_gpu(ctx, &lambda, params, &derived)
             }
             (Device::Gpu, Algo::Grain) => {
                 check_cancel(cancel)?;
-                let ctx = gpu_ctx.expect("gpu context initialized");
+                let ctx = gpu_ctx.as_ref().expect("gpu context initialized").as_ref();
                 wgpu::render_grainwise_gpu(ctx, &lambda, params, &derived)
             }
             (_, Algo::Auto) => unreachable!("auto selection resolved before rendering"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod pixelwise;
 mod rng;
 pub mod wgpu;
 
+pub use color::InputImage;
 pub use params::{
     Algo, CliArgs, ColorMode, Device, MaxRadius, Params, ParamsError, ParamsResult, RadiusDist,
     Roi, build_params, default_cell_delta,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use film_grain::{Algo, CliArgs, ColorMode, Device, RadiusDist, RenderStats};
 
@@ -165,7 +165,7 @@ struct Cli {
         long,
         value_name = "DEVICE",
         value_enum,
-        default_value_t = Device::Gpu,
+        default_value_t = Device::Cpu,
         help_heading = "DEVICE",
         help = "'cpu' | 'gpu'"
     )]
@@ -246,7 +246,7 @@ struct Cli {
     seed: u32,
 }
 
-fn print_stats(stats: &RenderStats, explain: bool, dry_run: bool, output: &PathBuf) {
+fn print_stats(stats: &RenderStats, explain: bool, dry_run: bool, output: &Path) {
     if dry_run {
         println!(
             "dry-run: {:?} algorithm, input {}x{} → output {}x{}, samples {}",

--- a/src/params.rs
+++ b/src/params.rs
@@ -346,10 +346,10 @@ fn ensure_size(size: Option<(u32, Option<u32>)>) -> ParamsResult<Option<(u32, Op
         if width == 0 {
             return Err(ParamsError::new("size", "output width must be > 0"));
         }
-        if let Some(height) = maybe_height {
-            if height == 0 {
-                return Err(ParamsError::new("size", "output height must be > 0"));
-            }
+        if let Some(height) = maybe_height
+            && height == 0
+        {
+            return Err(ParamsError::new("size", "output height must be > 0"));
         }
         Ok(Some((width, maybe_height)))
     } else {

--- a/src/params.rs
+++ b/src/params.rs
@@ -68,6 +68,29 @@ pub struct Params {
 }
 
 #[derive(Debug, Clone)]
+pub struct ParamsBuilder {
+    pub input_path: PathBuf,
+    pub output_path: PathBuf,
+    pub radius_dist: RadiusDist,
+    pub radius_mean: f32,
+    pub radius_stddev: f32,
+    pub zoom: f32,
+    pub sigma_px: f32,
+    pub n_samples: u32,
+    pub algo: Algo,
+    pub max_radius: MaxRadius,
+    pub cell_delta: Option<f32>,
+    pub color_mode: ColorMode,
+    pub roi: Option<Roi>,
+    pub size: Option<(u32, Option<u32>)>,
+    pub seed: u64,
+    pub dry_run: bool,
+    pub explain: bool,
+    pub device: Device,
+    pub output_format: Option<String>,
+}
+
+#[derive(Debug, Clone)]
 pub struct CliArgs {
     pub input_path: PathBuf,
     pub output_path: PathBuf,
@@ -115,43 +138,86 @@ impl fmt::Display for ParamsError {
 
 impl std::error::Error for ParamsError {}
 
+impl ParamsBuilder {
+    pub fn build(self) -> ParamsResult<Params> {
+        let radius_mean = ensure_positive(self.radius_mean, "radius")?;
+        let radius_stddev_input = ensure_non_negative(self.radius_stddev, "radius-stddev")?;
+        let zoom = ensure_positive(self.zoom, "zoom")?;
+        let sigma_px = ensure_positive(self.sigma_px, "sigma")?;
+        let n_samples = self.n_samples.max(1);
+        let max_radius = ensure_max_radius(self.max_radius)?;
+        let roi = ensure_roi(self.roi)?;
+        let size = ensure_size(self.size)?;
+        let cell_delta = ensure_cell_delta(self.cell_delta, radius_mean)?;
+
+        let (radius_stddev, radius_log_mu, radius_log_sigma) =
+            derive_radius_parameters(radius_mean, radius_stddev_input, self.radius_dist)?;
+
+        Ok(Params {
+            input_path: self.input_path,
+            output_path: self.output_path,
+            radius_dist: self.radius_dist,
+            radius_mean,
+            radius_stddev,
+            radius_log_mu,
+            radius_log_sigma,
+            zoom,
+            sigma_px,
+            n_samples,
+            algo: self.algo,
+            max_radius,
+            cell_delta,
+            color_mode: self.color_mode,
+            roi,
+            size,
+            seed: self.seed,
+            dry_run: self.dry_run,
+            explain: self.explain,
+            device: self.device,
+            output_format: self.output_format,
+        })
+    }
+}
+
+impl TryFrom<CliArgs> for ParamsBuilder {
+    type Error = ParamsError;
+
+    fn try_from(args: CliArgs) -> ParamsResult<Self> {
+        let radius_mean = to_positive_f32(args.radius_mean, "radius")?;
+        let radius_stddev = to_non_negative_f32(args.radius_stddev, "radius-stddev")?;
+        let zoom = to_positive_f32(args.zoom, "zoom")?;
+        let sigma_px = to_positive_f32(args.sigma_px, "sigma")?;
+        let cell_delta = parse_cell_delta(&args.cell, radius_mean)?;
+        let max_radius = parse_max_radius(&args.max_radius)?;
+        let roi = parse_roi(args.roi.as_deref())?;
+        let size = parse_size(args.size.as_deref())?;
+
+        Ok(Self {
+            input_path: args.input_path,
+            output_path: args.output_path,
+            radius_dist: args.radius_dist,
+            radius_mean,
+            radius_stddev,
+            zoom,
+            sigma_px,
+            n_samples: args.n_samples,
+            algo: args.algo,
+            max_radius,
+            cell_delta,
+            color_mode: args.color_mode,
+            roi,
+            size,
+            seed: args.seed as u64,
+            dry_run: args.dry_run,
+            explain: args.explain,
+            device: args.device,
+            output_format: args.output_format,
+        })
+    }
+}
+
 pub fn build_params(args: CliArgs) -> ParamsResult<Params> {
-    let radius_mean = to_positive_f32(args.radius_mean, "radius")?;
-    let radius_stddev = to_non_negative_f32(args.radius_stddev, "radius-stddev")?;
-    let zoom = to_positive_f32(args.zoom, "zoom")?;
-    let sigma_px = to_positive_f32(args.sigma_px, "sigma")?;
-
-    let (radius_stddev, radius_log_mu, radius_log_sigma) =
-        derive_radius_parameters(radius_mean, radius_stddev, args.radius_dist)?;
-
-    let cell_delta = parse_cell_delta(&args.cell, radius_mean)?;
-    let max_radius = parse_max_radius(&args.max_radius)?;
-    let roi = parse_roi(args.roi.as_deref())?;
-    let size = parse_size(args.size.as_deref())?;
-
-    Ok(Params {
-        input_path: args.input_path,
-        output_path: args.output_path,
-        radius_dist: args.radius_dist,
-        radius_mean,
-        radius_stddev,
-        radius_log_mu,
-        radius_log_sigma,
-        zoom,
-        sigma_px,
-        n_samples: args.n_samples.max(1),
-        algo: args.algo,
-        max_radius,
-        cell_delta,
-        color_mode: args.color_mode,
-        roi,
-        size,
-        seed: args.seed as u64,
-        dry_run: args.dry_run,
-        explain: args.explain,
-        device: args.device,
-        output_format: args.output_format,
-    })
+    ParamsBuilder::try_from(args)?.build()
 }
 
 fn derive_radius_parameters(
@@ -192,6 +258,103 @@ pub fn default_cell_delta(radius_mean: f32) -> f32 {
     }
     let inv = (1.0 / radius_mean).ceil().max(1.0);
     1.0 / inv
+}
+
+fn ensure_positive(value: f32, field: &'static str) -> ParamsResult<f32> {
+    if !value.is_finite() {
+        return Err(ParamsError::new(field, "value must be finite"));
+    }
+    if value <= 0.0 {
+        return Err(ParamsError::new(field, "value must be greater than 0"));
+    }
+    Ok(value)
+}
+
+fn ensure_non_negative(value: f32, field: &'static str) -> ParamsResult<f32> {
+    if !value.is_finite() {
+        return Err(ParamsError::new(field, "value must be finite"));
+    }
+    if value < 0.0 {
+        return Err(ParamsError::new(field, "value must be >= 0"));
+    }
+    Ok(value)
+}
+
+fn ensure_cell_delta(value: Option<f32>, radius_mean: f32) -> ParamsResult<Option<f32>> {
+    match value {
+        Some(delta) => {
+            if !delta.is_finite() {
+                return Err(ParamsError::new("cell", "cell size must be finite"));
+            }
+            if delta <= 0.0 {
+                return Err(ParamsError::new("cell", "cell size must be > 0"));
+            }
+            Ok(Some(delta))
+        }
+        None => Ok(Some(default_cell_delta(radius_mean))),
+    }
+}
+
+fn ensure_max_radius(spec: MaxRadius) -> ParamsResult<MaxRadius> {
+    match spec {
+        MaxRadius::Absolute(value) => {
+            if !value.is_finite() {
+                return Err(ParamsError::new(
+                    "max-radius",
+                    "absolute radius must be finite",
+                ));
+            }
+            if value <= 0.0 {
+                return Err(ParamsError::new(
+                    "max-radius",
+                    "absolute radius must be > 0",
+                ));
+            }
+            Ok(MaxRadius::Absolute(value))
+        }
+        MaxRadius::Quantile(value) => {
+            if !value.is_finite() {
+                return Err(ParamsError::new("max-radius", "quantile must be finite"));
+            }
+            if !(0.0 < value && value < 1.0) {
+                return Err(ParamsError::new(
+                    "max-radius",
+                    "quantile must lie in the open interval (0,1)",
+                ));
+            }
+            Ok(MaxRadius::Quantile(value))
+        }
+    }
+}
+
+fn ensure_roi(roi: Option<Roi>) -> ParamsResult<Option<Roi>> {
+    if let Some(r) = roi {
+        if r.x1 <= r.x0 || r.y1 <= r.y0 {
+            return Err(ParamsError::new(
+                "roi",
+                "roi end must be greater than start (exclusive bounds)",
+            ));
+        }
+        Ok(Some(r))
+    } else {
+        Ok(None)
+    }
+}
+
+fn ensure_size(size: Option<(u32, Option<u32>)>) -> ParamsResult<Option<(u32, Option<u32>)>> {
+    if let Some((width, maybe_height)) = size {
+        if width == 0 {
+            return Err(ParamsError::new("size", "output width must be > 0"));
+        }
+        if let Some(height) = maybe_height {
+            if height == 0 {
+                return Err(ParamsError::new("size", "output height must be > 0"));
+            }
+        }
+        Ok(Some((width, maybe_height)))
+    } else {
+        Ok(None)
+    }
 }
 
 fn to_positive_f32(value: f64, field: &'static str) -> ParamsResult<f32> {

--- a/src/pixelwise.rs
+++ b/src/pixelwise.rs
@@ -19,7 +19,6 @@ pub fn render_pixelwise(lambda: &Plane, params: &Params, derived: &Derived) -> P
         .par_chunks_mut(out_w)
         .enumerate()
         .for_each(|(y, row)| {
-            let y = y as usize;
             for (x, value) in row.iter_mut().enumerate() {
                 let mut sum = 0.0f32;
                 for offset in offsets_input {

--- a/src/pixelwise.rs
+++ b/src/pixelwise.rs
@@ -6,8 +6,14 @@ use rayon::slice::ParallelSliceMut;
 use crate::model::{Derived, Plane};
 use crate::params::Params;
 use crate::rng;
+use crate::{RenderError, RenderResult};
 
-pub fn render_pixelwise(lambda: &Plane, params: &Params, derived: &Derived) -> Plane {
+pub fn render_pixelwise(
+    lambda: &Plane,
+    params: &Params,
+    derived: &Derived,
+    cancel: Option<&(dyn Fn() -> bool + Send + Sync)>,
+) -> RenderResult<Plane> {
     let out_w = derived.output_width;
     let out_h = derived.output_height;
     let mut pixels = vec![0.0f32; out_w * out_h];
@@ -15,10 +21,14 @@ pub fn render_pixelwise(lambda: &Plane, params: &Params, derived: &Derived) -> P
     let inv_zoom = 1.0 / params.zoom;
     let offsets_input = &derived.offsets_input;
 
-    pixels
+    let cancel = cancel;
+    let render_result: Result<(), RenderError> = pixels
         .par_chunks_mut(out_w)
         .enumerate()
-        .for_each(|(y, row)| {
+        .try_for_each(move |(y, row)| {
+            if cancel.map_or(false, |check| check()) {
+                return Err(RenderError::Cancelled);
+            }
             for (x, value) in row.iter_mut().enumerate() {
                 let mut sum = 0.0f32;
                 for offset in offsets_input {
@@ -28,9 +38,11 @@ pub fn render_pixelwise(lambda: &Plane, params: &Params, derived: &Derived) -> P
                 }
                 *value = sum * inv_samples;
             }
+            Ok(())
         });
+    render_result?;
 
-    Plane::from_vec(out_w, out_h, pixels)
+    Ok(Plane::from_vec(out_w, out_h, pixels))
 }
 
 fn evaluate_indicator(xg: f32, yg: f32, lambda: &Plane, params: &Params, derived: &Derived) -> f32 {

--- a/src/wgpu/mod.rs
+++ b/src/wgpu/mod.rs
@@ -67,11 +67,14 @@ fn init() -> Result<GpuContext, RenderError> {
     }))
     .ok_or_else(|| RenderError::Gpu("no compatible GPU adapter found".into()))?;
 
+    let adapter_limits = adapter.limits();
     let (device, queue) = block_on(adapter.request_device(
         &wgpu::DeviceDescriptor {
             label: Some("filmgrain-device"),
             required_features: wgpu::Features::empty(),
-            required_limits: wgpu::Limits::default(),
+            // Request the full limits the adapter reports so large outputs aren't capped by the
+            // conservative WebGPU defaults (e.g. 256 MiB max buffer size).
+            required_limits: adapter_limits,
         },
         None,
     ))

--- a/src/wgpu/mod.rs
+++ b/src/wgpu/mod.rs
@@ -1,6 +1,7 @@
-use std::sync::OnceLock;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use bytemuck::{Pod, Zeroable};
+use log::{error, warn};
 use pollster::block_on;
 use wgpu::util::DeviceExt;
 
@@ -11,7 +12,7 @@ use crate::params::{Params, RadiusDist};
 const PIXEL_SHADER: &str = include_str!("shaders/pixel_wise.wgsl");
 const GRAIN_SHADER: &str = include_str!("shaders/grain_wise.wgsl");
 
-static GPU_CONTEXT: OnceLock<GpuContext> = OnceLock::new();
+static GPU_CONTEXT: OnceLock<GpuContextCache> = OnceLock::new();
 
 #[repr(C)]
 #[derive(Clone, Copy, Pod, Zeroable)]
@@ -47,15 +48,47 @@ pub struct GpuContext {
     grain_reduce_pipeline: wgpu::ComputePipeline,
 }
 
-pub fn context() -> Result<&'static GpuContext, RenderError> {
-    if let Some(ctx) = GPU_CONTEXT.get() {
-        return Ok(ctx);
+struct GpuContextCache {
+    ctx: Mutex<Option<Arc<GpuContext>>>,
+}
+
+impl Default for GpuContextCache {
+    fn default() -> Self {
+        Self {
+            ctx: Mutex::new(None),
+        }
     }
-    let ctx = init()?;
-    GPU_CONTEXT
-        .set(ctx)
-        .map_err(|_| RenderError::Gpu("GPU context already initialized".into()))?;
-    Ok(GPU_CONTEXT.get().expect("gpu context set"))
+}
+
+impl GpuContextCache {
+    fn get(&self) -> Result<Arc<GpuContext>, RenderError> {
+        let mut guard = self.ctx.lock().unwrap_or_else(|err| err.into_inner());
+        if let Some(ctx) = guard.as_ref() {
+            return Ok(ctx.clone());
+        }
+        let ctx = Arc::new(init()?);
+        *guard = Some(ctx.clone());
+        Ok(ctx)
+    }
+
+    fn invalidate(&self) {
+        let mut guard = self.ctx.lock().unwrap_or_else(|err| err.into_inner());
+        guard.take();
+    }
+}
+
+fn cache() -> &'static GpuContextCache {
+    GPU_CONTEXT.get_or_init(GpuContextCache::default)
+}
+
+pub fn context() -> Result<Arc<GpuContext>, RenderError> {
+    cache().get()
+}
+
+fn invalidate_context() {
+    if let Some(cache) = GPU_CONTEXT.get() {
+        cache.invalidate();
+    }
 }
 
 fn init() -> Result<GpuContext, RenderError> {
@@ -79,6 +112,10 @@ fn init() -> Result<GpuContext, RenderError> {
         None,
     ))
     .map_err(|err| RenderError::Gpu(format!("request_device failed: {err}")))?;
+
+    device.on_uncaptured_error(Box::new(|err| {
+        log_uncaptured_error(err);
+    }));
 
     let pixel_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("pixel-wise shader"),
@@ -302,6 +339,17 @@ pub fn render_pixelwise_gpu(
     params: &Params,
     d: &Derived,
 ) -> Result<Plane, RenderError> {
+    run_with_gpu_error_scope(ctx, "Pixel renderer", || {
+        render_pixelwise_gpu_inner(ctx, lambda, params, d)
+    })
+}
+
+fn render_pixelwise_gpu_inner(
+    ctx: &GpuContext,
+    lambda: &Plane,
+    params: &Params,
+    d: &Derived,
+) -> Result<Plane, RenderError> {
     let offsets = &d.offsets_input;
     if offsets.len() != params.n_samples as usize {
         return Err(RenderError::Gpu(
@@ -423,6 +471,17 @@ pub fn render_pixelwise_gpu(
 }
 
 pub fn render_grainwise_gpu(
+    ctx: &GpuContext,
+    lambda: &Plane,
+    params: &Params,
+    d: &Derived,
+) -> Result<Plane, RenderError> {
+    run_with_gpu_error_scope(ctx, "Grain renderer", || {
+        render_grainwise_gpu_inner(ctx, lambda, params, d)
+    })
+}
+
+fn render_grainwise_gpu_inner(
     ctx: &GpuContext,
     lambda: &Plane,
     params: &Params,
@@ -638,4 +697,66 @@ fn div_round_up(a: usize, b: u32) -> u32 {
 
 fn lanes_for_samples(samples: u32) -> u32 {
     samples.div_ceil(32)
+}
+
+fn run_with_gpu_error_scope<T, F>(
+    ctx: &GpuContext,
+    label: &'static str,
+    work: F,
+) -> Result<T, RenderError>
+where
+    F: FnOnce() -> Result<T, RenderError>,
+{
+    ctx.device.push_error_scope(wgpu::ErrorFilter::Validation);
+    ctx.device.push_error_scope(wgpu::ErrorFilter::OutOfMemory);
+    ctx.device.push_error_scope(wgpu::ErrorFilter::Internal);
+
+    let work_result = work();
+
+    let internal = block_on(ctx.device.pop_error_scope());
+    let out_of_memory = block_on(ctx.device.pop_error_scope());
+    let validation = block_on(ctx.device.pop_error_scope());
+
+    if let Some(err) = validation.or(out_of_memory).or(internal) {
+        return Err(handle_gpu_error(label, err));
+    }
+
+    work_result
+}
+
+fn handle_gpu_error(label: &str, err: wgpu::Error) -> RenderError {
+    let (message, fatal) = describe_gpu_error(label, &err);
+    if fatal {
+        error!("{msg}", msg = &message);
+        invalidate_context();
+    } else {
+        warn!("{msg}", msg = &message);
+    }
+    RenderError::Gpu(message)
+}
+
+fn describe_gpu_error(label: &str, err: &wgpu::Error) -> (String, bool) {
+    match err {
+        wgpu::Error::OutOfMemory { .. } => (
+            format!("{label} ran out of GPU memory. Try lowering the output size or sample count."),
+            true,
+        ),
+        wgpu::Error::Validation { description, .. } => {
+            (format!("{label} validation error: {description}"), false)
+        }
+        wgpu::Error::Internal { description, .. } => (
+            format!("{label} hit an internal GPU error: {description}"),
+            true,
+        ),
+    }
+}
+
+fn log_uncaptured_error(err: wgpu::Error) {
+    let (message, fatal) = describe_gpu_error("wgpu", &err);
+    if fatal {
+        error!("{msg}", msg = &message);
+        invalidate_context();
+    } else {
+        warn!("{msg}", msg = &message);
+    }
 }

--- a/src/wgpu/mod.rs
+++ b/src/wgpu/mod.rs
@@ -262,6 +262,7 @@ fn init() -> Result<GpuContext, RenderError> {
         layout: Some(&pixel_pipeline_layout),
         module: &pixel_shader,
         entry_point: "main",
+        compilation_options: Default::default(),
     });
 
     let grain_splat_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
@@ -269,6 +270,7 @@ fn init() -> Result<GpuContext, RenderError> {
         layout: Some(&grain_splat_pipeline_layout),
         module: &grain_shader,
         entry_point: "splat",
+        compilation_options: Default::default(),
     });
 
     let grain_reduce_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
@@ -276,6 +278,7 @@ fn init() -> Result<GpuContext, RenderError> {
         layout: Some(&grain_reduce_pipeline_layout),
         module: &grain_shader,
         entry_point: "reduce",
+        compilation_options: Default::default(),
     });
 
     Ok(GpuContext {

--- a/src/wgpu/mod.rs
+++ b/src/wgpu/mod.rs
@@ -307,7 +307,7 @@ pub fn render_pixelwise_gpu(
     let lambda_bytes = bytemuck::cast_slice(lambda.pixels());
     let offsets_bytes = bytemuck::cast_slice(offsets);
     let uniforms_bytes = bytemuck::bytes_of(&uniforms);
-    let out_len = (d.output_width * d.output_height) as usize;
+    let out_len = d.output_width * d.output_height;
     let out_bytes = out_len * std::mem::size_of::<f32>();
 
     let lambda_buffer = ctx
@@ -435,7 +435,7 @@ pub fn render_grainwise_gpu(
     let offsets_bytes = bytemuck::cast_slice(offsets);
     let uniforms_bytes = bytemuck::bytes_of(&uniforms);
 
-    let out_len = (d.output_width * d.output_height) as usize;
+    let out_len = d.output_width * d.output_height;
     let bitset_words = out_len * lanes as usize;
     let bitset_bytes = bitset_words * std::mem::size_of::<u32>();
     let out_bytes = out_len * std::mem::size_of::<f32>();
@@ -627,9 +627,9 @@ fn build_uniforms(params: &Params, derived: &Derived, lanes: u32) -> Uniforms {
 }
 
 fn div_round_up(a: usize, b: u32) -> u32 {
-    ((a as u32) + b - 1) / b
+    (a as u32).div_ceil(b)
 }
 
 fn lanes_for_samples(samples: u32) -> u32 {
-    ((samples + 31) / 32).max(1)
+    samples.div_ceil(32)
 }


### PR DESCRIPTION
This pull request introduces an interactive viewer you can use to preview different settings in real time! It should be the default way to use this program now.

In order to accomidate this change, several core systems needed to be rewritten.

### API and Type Refactoring

* Added a new `InputImage` struct to encapsulate image loading and conversion, allowing rendering from in-memory images and supporting ROI and color mode selection.
* Introduced `ParamsBuilder` for easier and safer construction of rendering parameters/

### Rendering Pipeline Enhancements

* Refactored the rendering pipeline to support new methods: `render_to_image`, `render_with_input_image`, and their cancelable and dry-run variants, enabling rendering without direct file I/O and supporting cancellation.
* Changed the main `render_grainwise` function to accept a cancellation callback and return a `Result`, propagating cancellation errors throughout the pipeline.
* Added a new `Cancelled` variant to the `RenderError` enum for unified cancellation error handling.

### Dependency Updates

* Updated and added dependencies in `Cargo.toml` to support new features and GUI integration (e.g., `wgpu` 0.20, `eframe`, `egui_extras`, `rfd`, `log`).

### Miscellaneous Improvements

* Changed the default device in CLI from GPU to CPU for broader compatibility. 
* Improved code modularity and maintainability by extracting shared logic (e.g., workspace dimension calculation, workspace kind cloning).